### PR TITLE
Remove parameterized

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dev = [
     "pytest == 8.0.0",
     "pytest-xdist == 3.5.0",
     "hypothesis == 6.99.6",
-    "parameterized == 0.8.1",
     # Documentation
     "pep8-naming == 0.13.3",
     "Sphinx == 5.1.1",

--- a/test/lib/test_connectors.py
+++ b/test/lib/test_connectors.py
@@ -3,7 +3,6 @@ import random
 from operator import and_
 from functools import reduce
 from typing import TypeAlias
-from parameterized import parameterized
 
 from amaranth import *
 from transactron import *
@@ -59,23 +58,23 @@ class TestFifoBase(TestCaseWithSimulator):
 
 
 class TestFIFO(TestFifoBase):
-    @parameterized.expand([(0, 0), (2, 0), (0, 2), (1, 1)])
+    @pytest.mark.parametrize("writer_rand, reader_rand", [(0, 0), (2, 0), (0, 2), (1, 1)])
     def test_fifo(self, writer_rand, reader_rand):
         self.do_test_fifo(FIFO, writer_rand=writer_rand, reader_rand=reader_rand, fifo_kwargs=dict(depth=4))
 
 
 class TestConnect(TestFifoBase):
-    @parameterized.expand([(0, 0), (2, 0), (0, 2), (1, 1)])
+    @pytest.mark.parametrize("writer_rand, reader_rand", [(0, 0), (2, 0), (0, 2), (1, 1)])
     def test_fifo(self, writer_rand, reader_rand):
         self.do_test_fifo(Connect, writer_rand=writer_rand, reader_rand=reader_rand)
 
-    @parameterized.expand([(0, 0), (2, 0), (0, 2), (1, 1)])
+    @pytest.mark.parametrize("writer_rand, reader_rand", [(0, 0), (2, 0), (0, 2), (1, 1)])
     def test_rev_fifo(self, writer_rand, reader_rand):
         self.do_test_fifo(RevConnect, writer_rand=writer_rand, reader_rand=reader_rand)
 
 
 class TestForwarder(TestFifoBase):
-    @parameterized.expand([(0, 0), (2, 0), (0, 2), (1, 1)])
+    @pytest.mark.parametrize("writer_rand, reader_rand", [(0, 0), (2, 0), (0, 2), (1, 1)])
     def test_fifo(self, writer_rand, reader_rand):
         self.do_test_fifo(Forwarder, writer_rand=writer_rand, reader_rand=reader_rand)
 
@@ -116,7 +115,7 @@ class TestForwarder(TestFifoBase):
 
 
 class TestPipe(TestFifoBase):
-    @parameterized.expand([(0, 0), (2, 0), (0, 2), (1, 1)])
+    @pytest.mark.parametrize("writer_rand, reader_rand", [(0, 0), (2, 0), (0, 2), (1, 1)])
     def test_fifo(self, writer_rand, reader_rand):
         self.do_test_fifo(Pipe, writer_rand=writer_rand, reader_rand=reader_rand)
 

--- a/test/lib/test_fifo.py
+++ b/test/lib/test_fifo.py
@@ -1,10 +1,10 @@
+import pytest
 from amaranth import *
 
 from transactron.lib import AdapterTrans, BasicFifo
 
 from transactron.testing import TestCaseWithSimulator, TestbenchIO, data_layout, TestbenchContext
 from collections import deque
-from parameterized import parameterized_class
 import random
 
 
@@ -24,18 +24,10 @@ class BasicFifoTestCircuit(Elaboratable):
         return m
 
 
-@parameterized_class(
-    ("name", "depth"),
-    [
-        ("notpower", 5),
-        ("power", 4),
-    ],
-)
 class TestBasicFifo(TestCaseWithSimulator):
-    depth: int
-
-    def test_randomized(self):
-        fifoc = BasicFifoTestCircuit(depth=self.depth)
+    @pytest.mark.parametrize("depth", [5, 4])
+    def test_randomized(self, depth):
+        fifoc = BasicFifoTestCircuit(depth=depth)
         expq = deque()
 
         cycles = 256

--- a/test/lib/test_transformers.py
+++ b/test/lib/test_transformers.py
@@ -1,5 +1,5 @@
+import pytest
 import random
-from parameterized import parameterized
 
 from amaranth import *
 from transactron import *
@@ -137,7 +137,7 @@ class TestMethodFilter(TestCaseWithSimulator):
         with self.run_simulation(m) as sim:
             sim.add_testbench(self.source)
 
-    @parameterized.expand([(True,), (False,)])
+    @pytest.mark.parametrize("use_condition", [True, False])
     def test_method_filter_plain(self, use_condition):
         self.initialize()
 
@@ -182,7 +182,7 @@ class MethodProductTestCircuit(Elaboratable):
 
 
 class TestMethodProduct(TestCaseWithSimulator):
-    @parameterized.expand([(1, False), (2, False), (5, True)])
+    @pytest.mark.parametrize("targets, add_combiner", [(1, False), (2, False), (5, True)])
     def test_method_product(self, targets: int, add_combiner: bool):
         random.seed(14)
 
@@ -226,7 +226,7 @@ class TestMethodProduct(TestCaseWithSimulator):
 
 
 class TestMethodTryProduct(TestCaseWithSimulator):
-    @parameterized.expand([(1, False), (2, False), (5, True)])
+    @pytest.mark.parametrize("targets, add_combiner", [(1, False), (2, False), (5, True)])
     def test_method_try_product(self, targets: int, add_combiner: bool):
         random.seed(14)
 

--- a/test/test_connectors.py
+++ b/test/test_connectors.py
@@ -1,30 +1,26 @@
+import pytest
 import random
-from parameterized import parameterized_class
 
 from transactron.lib import StableSelectingNetwork
 from transactron.testing import TestCaseWithSimulator, TestbenchContext
 
 
-@parameterized_class(
-    ("n"),
-    [(2,), (3,), (7,), (8,)],
-)
 class TestStableSelectingNetwork(TestCaseWithSimulator):
-    n: int
 
-    def test(self):
-        m = StableSelectingNetwork(self.n, [("data", 8)])
+    @pytest.mark.parametrize("n", [2, 3, 7, 8])
+    def test(self, n: int):
+        m = StableSelectingNetwork(n, [("data", 8)])
 
         random.seed(42)
 
         async def process(sim: TestbenchContext):
             for _ in range(100):
-                inputs = [random.randrange(2**8) for _ in range(self.n)]
-                valids = [random.randrange(2) for _ in range(self.n)]
+                inputs = [random.randrange(2**8) for _ in range(n)]
+                valids = [random.randrange(2) for _ in range(n)]
                 total = sum(valids)
 
                 expected_output_prefix = []
-                for i in range(self.n):
+                for i in range(n):
                     sim.set(m.valids[i], valids[i])
                     sim.set(m.inputs[i].data, inputs[i])
 

--- a/test/test_methods.py
+++ b/test/test_methods.py
@@ -11,8 +11,6 @@ from transactron.testing.infrastructure import SimpleTestCircuit
 from transactron.utils import MethodStruct
 from transactron.lib import *
 
-from parameterized import parameterized
-
 from unittest import TestCase
 
 from transactron.utils.assign import AssignArg
@@ -388,7 +386,7 @@ class Quadruple2(Elaboratable):
 
 
 class TestQuadrupleCircuits(TestCaseWithSimulator):
-    @parameterized.expand([(Quadruple,), (Quadruple2,)])
+    @pytest.mark.parametrize("quadruple", [Quadruple, Quadruple2])
     def test(self, quadruple):
         circ = QuadrupleCircuit(quadruple())
 
@@ -505,13 +503,14 @@ class TestConditionals(TestCaseWithSimulator):
         with self.run_simulation(circ) as sim:
             sim.add_testbench(process)
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "elaboratable",
         [
-            (ConditionalMethodCircuit1,),
-            (ConditionalMethodCircuit2,),
-            (ConditionalTransactionCircuit1,),
-            (ConditionalTransactionCircuit2,),
-        ]
+            ConditionalMethodCircuit1,
+            ConditionalMethodCircuit2,
+            ConditionalTransactionCircuit1,
+            ConditionalTransactionCircuit2,
+        ],
     )
     def test_conditional(self, elaboratable):
         circ = elaboratable()

--- a/test/utils/test_onehotswitch.py
+++ b/test/utils/test_onehotswitch.py
@@ -1,11 +1,10 @@
+import pytest
 from amaranth import *
 from amaranth.sim import *
 
 from transactron.utils import OneHotSwitch
 
 from transactron.testing import TestCaseWithSimulator, TestbenchContext
-
-from parameterized import parameterized
 
 
 class OneHotSwitchCircuit(Elaboratable):
@@ -31,7 +30,7 @@ class OneHotSwitchCircuit(Elaboratable):
 
 
 class TestOneHotSwitch(TestCaseWithSimulator):
-    @parameterized.expand([(False,), (True,)])
+    @pytest.mark.parametrize("test_zero", [False, True])
     def test_onehotswitch(self, test_zero):
         circuit = OneHotSwitchCircuit(4, test_zero)
 

--- a/test/utils/test_utils.py
+++ b/test/utils/test_utils.py
@@ -1,5 +1,6 @@
 import unittest
 import random
+import pytest
 
 from amaranth import *
 from transactron.testing import *
@@ -10,7 +11,6 @@ from transactron.utils import (
     count_leading_zeros,
     count_trailing_zeros,
 )
-from parameterized import parameterized_class
 
 
 class TestAlignToPowerOfTwo(unittest.TestCase):
@@ -66,14 +66,11 @@ class PopcountTestCircuit(Elaboratable):
         return m
 
 
-@parameterized_class(
-    ("name", "size"),
-    [("size" + str(s), s) for s in [2, 3, 4, 5, 6, 8, 10, 16, 21, 32, 33, 64, 1025]],
-)
+@pytest.mark.parametrize("size", [2, 3, 4, 5, 6, 8, 10, 16, 21, 32, 33, 64, 1025])
 class TestPopcount(TestCaseWithSimulator):
-    size: int
-
-    def setup_method(self):
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_fixture(self, size):
+        self.size = size
         random.seed(14)
         self.test_number = 40
         self.m = PopcountTestCircuit(self.size)
@@ -90,7 +87,7 @@ class TestPopcount(TestCaseWithSimulator):
             sim.delay(1e-6)
         self.check(sim, 2**self.size - 1)
 
-    def test_popcount(self):
+    def test_popcount(self, size):
         with self.run_simulation(self.m) as sim:
             sim.add_testbench(self.process)
 
@@ -112,17 +109,15 @@ class CLZTestCircuit(Elaboratable):
         return m
 
 
-@parameterized_class(
-    ("name", "size"),
-    [("size" + str(s), s) for s in range(1, 7)],
-)
+@pytest.mark.parametrize("size", range(1, 7))
 class TestCountLeadingZeros(TestCaseWithSimulator):
-    size: int
-
-    def setup_method(self):
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_fixture(self, size):
+        self.size = size
         random.seed(14)
         self.test_number = 40
         self.m = CLZTestCircuit(self.size)
+        yield
 
     def check(self, sim: TestbenchContext, n):
         sim.set(self.m.sig_in, n)
@@ -136,7 +131,7 @@ class TestCountLeadingZeros(TestCaseWithSimulator):
             sim.delay(1e-6)
         self.check(sim, 2**self.size - 1)
 
-    def test_count_leading_zeros(self):
+    def test_count_leading_zeros(self, size):
         with self.run_simulation(self.m) as sim:
             sim.add_testbench(self.process)
 
@@ -158,14 +153,11 @@ class CTZTestCircuit(Elaboratable):
         return m
 
 
-@parameterized_class(
-    ("name", "size"),
-    [("size" + str(s), s) for s in range(1, 7)],
-)
+@pytest.mark.parametrize("size", range(1, 7))
 class TestCountTrailingZeros(TestCaseWithSimulator):
-    size: int
-
-    def setup_method(self):
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_fixture(self, size):
+        self.size = size
         random.seed(14)
         self.test_number = 40
         self.m = CTZTestCircuit(self.size)
@@ -191,6 +183,6 @@ class TestCountTrailingZeros(TestCaseWithSimulator):
             await sim.delay(1e-6)
         self.check(sim, 2**self.size - 1)
 
-    def test_count_trailing_zeros(self):
+    def test_count_trailing_zeros(self, size):
         with self.run_simulation(self.m) as sim:
             sim.add_testbench(self.process)

--- a/test/utils/test_utils.py
+++ b/test/utils/test_utils.py
@@ -117,7 +117,6 @@ class TestCountLeadingZeros(TestCaseWithSimulator):
         random.seed(14)
         self.test_number = 40
         self.m = CLZTestCircuit(self.size)
-        yield
 
     def check(self, sim: TestbenchContext, n):
         sim.set(self.m.sig_in, n)


### PR DESCRIPTION
This PR removes the dependency on `parameterized`, `pytest.mark.parametrize` is used instead. Based on #20.