### PR TITLE
Add missing `__all__`

### DIFF
--- a/test/test_methods.py
+++ b/test/test_methods.py
@@ -3,6 +3,7 @@ import pytest
 import random
 from amaranth import *
 from amaranth.sim import *
+from amaranth.lib.data import StructLayout
 
 from transactron.testing import TestCaseWithSimulator, TestbenchIO, data_layout
 
@@ -45,7 +46,7 @@ class TestDefMethod(TestCaseWithSimulator):
         self.do_test_definition(definition)
 
     def test_fields_valid2(self):
-        rec = Signal(from_method_layout([("bar1", 4), ("bar2", 6)]))
+        rec = Signal(StructLayout({"bar1": 4, "bar2": 6}))
 
         def definition(arg):
             return {"foo1": Signal(3), "foo2": rec}

--- a/test/testing/test_method_mock.py
+++ b/test/testing/test_method_mock.py
@@ -1,6 +1,7 @@
 import random
 from amaranth import *
 from amaranth.sim import *
+from amaranth.lib.data import StructLayout
 
 from transactron import *
 from transactron.testing import TestCaseWithSimulator, TestbenchContext
@@ -11,7 +12,7 @@ from transactron.lib import *
 
 class ReverseMethodMockTestCircuit(Elaboratable):
     def __init__(self, width):
-        self.method = Method(i=from_method_layout([("input", width)]), o=from_method_layout([("output", width)]))
+        self.method = Method(i=StructLayout({"input": width}), o=StructLayout({"output": width}))
 
     def elaborate(self, platform):
         m = TModule()

--- a/transactron/core/manager.py
+++ b/transactron/core/manager.py
@@ -1,5 +1,6 @@
 from collections import defaultdict, deque
-from typing import Callable, Iterable, Sequence, TypeAlias, Tuple
+from collections.abc import Callable, Iterable, Sequence, Collection, Mapping
+from typing import TypeAlias, Optional
 from os import environ
 from graphlib import TopologicalSorter
 from amaranth import *
@@ -89,7 +90,7 @@ class TransactionManager(Elaboratable):
         self.transactions.append(transaction)
 
     @staticmethod
-    def _conflict_graph(method_map: MethodMap) -> Tuple[TransactionGraph, PriorityOrder]:
+    def _conflict_graph(method_map: MethodMap) -> tuple[TransactionGraph, PriorityOrder]:
         """_conflict_graph
 
         This function generates the graph of transaction conflicts. Conflicts

--- a/transactron/core/transaction_base.py
+++ b/transactron/core/transaction_base.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from collections.abc import Iterator
 from contextlib import contextmanager
 from enum import Enum, auto
 from itertools import count
@@ -12,7 +13,7 @@ from typing import (
     Self,
     runtime_checkable,
     TYPE_CHECKING,
-    Iterator,
+    Optional,
 )
 from amaranth import *
 

--- a/transactron/lib/fifo.py
+++ b/transactron/lib/fifo.py
@@ -6,6 +6,9 @@ from transactron.utils.amaranth_ext import mod_incr
 from transactron.utils.transactron_helpers import from_method_layout, get_src_loc
 
 
+__all__ = ["BasicFifo", "Semaphore"]
+
+
 class BasicFifo(Elaboratable):
     """Transactional FIFO queue
 

--- a/transactron/lib/logging.py
+++ b/transactron/lib/logging.py
@@ -14,6 +14,10 @@ from transactron.utils import SrcLoc
 from transactron.utils._typing import ModuleLike, ValueLike
 from transactron.utils.dependencies import DependencyContext, ListKey
 
+
+__all__ = ["LogLevel", "LogRecordInfo", "LogRecord", "LogKey", "HardwareLogger", "get_log_records", "get_trigger_bit"]
+
+
 LogLevel: TypeAlias = int
 
 

--- a/transactron/utils/debug_signals.py
+++ b/transactron/utils/debug_signals.py
@@ -4,6 +4,9 @@ from ._typing import SignalBundle, HasDebugSignals
 from collections.abc import Collection, Mapping
 
 
+__all__ = ["auto_debug_signals"]
+
+
 def auto_debug_signals(thing) -> SignalBundle:
     """Automatic debug signal generation.
 


### PR DESCRIPTION
This PR adds missing `__all__` declarations, fixing accidental exports of unrelated stuff.