### PR TITLE
Transactron redesign: better proxying and cleaner implementation

### DIFF
--- a/docs/transactions.md
+++ b/docs/transactions.md
@@ -140,7 +140,7 @@ Suppose we have the following layout, which is an input layout for a method call
 
 ```python
 layout = [("foo", 1), ("bar", 32)]
-method = Method(input_layout=layout)
+method = Method(i=layout)
 ```
 
 The method can be called in multiple ways.
@@ -170,7 +170,7 @@ Take the following definitions:
 
 ```python
 layout2 = [("foobar", layout), ("baz", 42)]
-method2 = Method(input_layout=layout2)
+method2 = Method(i=layout2)
 ```
 
 One can then pass the arguments using `dict`s in following ways:
@@ -208,7 +208,7 @@ The `dict` syntax can be used for returning values from methods.
 Take the following method declaration:
 
 ```python
-method3 = Method(input_layout=layout, output_layout=layout2)
+method3 = Method(i=layout, o=layout2)
 ```
 
 One can then define this method as follows:

--- a/test/core/test_transactions.py
+++ b/test/core/test_transactions.py
@@ -10,6 +10,7 @@ import contextlib
 
 from collections import deque
 from typing import Iterable, Callable
+from transactron.core.keys import TransactionManagerKey
 
 from transactron.testing import TestCaseWithSimulator, TestbenchIO, data_layout
 
@@ -20,7 +21,7 @@ from transactron.utils import Scheduler
 from transactron.core import Priority
 from transactron.core.schedulers import trivial_roundrobin_cc_scheduler, eager_deterministic_cc_scheduler
 from transactron.core.manager import TransactionScheduler
-from transactron.utils.dependencies import DependencyContext
+from transactron.utils.dependencies import DependencyContext, DependencyManager
 
 
 class TestNames(TestCase):
@@ -28,25 +29,28 @@ class TestNames(TestCase):
         mgr = TransactionManager()
         mgr._MustUse__silence = True  # type: ignore
 
-        class T(Elaboratable):
-            def __init__(self):
-                self._MustUse__silence = True  # type: ignore
-                Transaction(manager=mgr)
+        with DependencyContext(DependencyManager()) as ctx:
+            ctx.manager.add_dependency(TransactionManagerKey(), mgr)
 
-        T()
-        assert mgr.transactions[0].name == "T"
+            class T(Elaboratable):
+                def __init__(self):
+                    self._MustUse__silence = True  # type: ignore
+                    Transaction()
 
-        t = Transaction(name="x", manager=mgr)
-        assert t.name == "x"
+            T()
+            assert mgr.transactions[0].name == "T"
 
-        t = Transaction(manager=mgr)
-        assert t.name == "t"
+            t = Transaction(name="x")
+            assert t.name == "x"
 
-        m = Method(name="x")
-        assert m.name == "x"
+            t = Transaction()
+            assert t.name == "t"
 
-        m = Method()
-        assert m.name == "m"
+            m = Method(name="x")
+            assert m.name == "x"
+
+            m = Method()
+            assert m.name == "m"
 
 
 class TestScheduler(TestCaseWithSimulator):
@@ -428,7 +432,11 @@ class SingleCallerTestCircuit(Elaboratable):
     def elaborate(self, platform):
         m = TModule()
 
-        method = Method(single_caller=True)
+        method = Method()
+
+        @def_method(m, method, single_caller=True)
+        def _():
+            pass
 
         with Transaction().body(m):
             method(m)

--- a/test/core/test_transactions.py
+++ b/test/core/test_transactions.py
@@ -115,7 +115,7 @@ class TransactionConflictTestCircuit(Elaboratable):
     def elaborate(self, platform):
         m = TModule()
         tm = TransactionModule(m, DependencyContext.get(), TransactionManager(self.scheduler))
-        adapter = Adapter(i=data_layout(32), o=data_layout(32))
+        adapter = Adapter.create(i=data_layout(32), o=data_layout(32))
         m.submodules.out = self.out = TestbenchIO(adapter)
         m.submodules.in1 = self.in1 = TestbenchIO(AdapterTrans(adapter.iface))
         m.submodules.in2 = self.in2 = TestbenchIO(AdapterTrans(adapter.iface))

--- a/test/lib/test_connectors.py
+++ b/test/lib/test_connectors.py
@@ -134,13 +134,13 @@ class ManyToOneConnectTransTestCircuit(Elaboratable):
 
         get_results = []
         for i in range(self.count):
-            input = TestbenchIO(Adapter(o=self.lay))
+            input = TestbenchIO(Adapter.create(o=self.lay))
             get_results.append(input.adapter.iface)
             m.submodules[f"input_{i}"] = input
             self.inputs.append(input)
 
         # Create ManyToOneConnectTrans, which will serialize results from different inputs
-        output = TestbenchIO(Adapter(i=self.lay))
+        output = TestbenchIO(Adapter.create(i=self.lay))
         m.submodules.output = self.output = output
         m.submodules.fu_arbitration = ManyToOneConnectTrans(get_results=get_results, put_result=output.adapter.iface)
 

--- a/test/lib/test_reqres.py
+++ b/test/lib/test_reqres.py
@@ -27,8 +27,8 @@ class TestSerializer(TestCaseWithSimulator):
 
         layout = [("field", self.data_width)]
 
-        self.req_method = TestbenchIO(Adapter(i=layout))
-        self.resp_method = TestbenchIO(Adapter(o=layout))
+        self.req_method = TestbenchIO(Adapter.create(i=layout))
+        self.resp_method = TestbenchIO(Adapter.create(o=layout))
 
         self.test_circuit = SimpleTestCircuit(
             Serializer(

--- a/test/lib/test_simultaneous.py
+++ b/test/lib/test_simultaneous.py
@@ -20,7 +20,7 @@ from transactron.testing import (
 class ConditionTestCircuit(Elaboratable):
     def __init__(self, target: Method, *, nonblocking: bool, priority: bool, catchall: bool):
         self.target = target
-        self.source = Method(i=[("cond1", 1), ("cond2", 1), ("cond3", 1)], single_caller=True)
+        self.source = Method(i=[("cond1", 1), ("cond2", 1), ("cond3", 1)])
         self.nonblocking = nonblocking
         self.priority = priority
         self.catchall = catchall
@@ -28,7 +28,7 @@ class ConditionTestCircuit(Elaboratable):
     def elaborate(self, platform):
         m = TModule()
 
-        @def_method(m, self.source)
+        @def_method(m, self.source, single_caller=True)
         def _(cond1, cond2, cond3):
             with condition(m, nonblocking=self.nonblocking, priority=self.priority) as branch:
                 with branch(cond1):

--- a/test/lib/test_simultaneous.py
+++ b/test/lib/test_simultaneous.py
@@ -49,7 +49,7 @@ class TestCondition(TestCaseWithSimulator):
     @pytest.mark.parametrize("priority", [False, True])
     @pytest.mark.parametrize("catchall", [False, True])
     def test_condition(self, nonblocking: bool, priority: bool, catchall: bool):
-        target = TestbenchIO(Adapter(i=[("cond", 2)]))
+        target = TestbenchIO(Adapter.create(i=[("cond", 2)]))
 
         circ = SimpleTestCircuit(
             ConditionTestCircuit(target.adapter.iface, nonblocking=nonblocking, priority=priority, catchall=catchall),

--- a/test/lib/test_transformers.py
+++ b/test/lib/test_transformers.py
@@ -51,7 +51,7 @@ class MethodMapTestCircuit(Elaboratable):
             itransform = itransform_rec
             otransform = otransform_rec
 
-        m.submodules.target = self.target = TestbenchIO(Adapter(i=layout, o=layout))
+        m.submodules.target = self.target = TestbenchIO(Adapter.create(i=layout, o=layout))
 
         if self.use_methods:
             imeth = Method(i=layout, o=layout)
@@ -111,8 +111,8 @@ class TestMethodFilter(TestCaseWithSimulator):
     def initialize(self):
         self.iosize = 4
         self.layout = data_layout(self.iosize)
-        self.target = TestbenchIO(Adapter(i=self.layout, o=self.layout))
-        self.cmeth = TestbenchIO(Adapter(i=self.layout, o=data_layout(1)))
+        self.target = TestbenchIO(Adapter.create(i=self.layout, o=self.layout))
+        self.cmeth = TestbenchIO(Adapter.create(i=self.layout, o=data_layout(1)))
 
     async def source(self, sim: TestbenchContext):
         for i in range(2**self.iosize):
@@ -165,7 +165,7 @@ class MethodProductTestCircuit(Elaboratable):
         methods = []
 
         for k in range(self.targets):
-            tgt = TestbenchIO(Adapter(i=layout, o=layout))
+            tgt = TestbenchIO(Adapter.create(i=layout, o=layout))
             methods.append(tgt.adapter.iface)
             self.target.append(tgt)
             m.submodules += tgt
@@ -280,7 +280,7 @@ class MethodTryProductTestCircuit(Elaboratable):
         methods = []
 
         for k in range(self.targets):
-            tgt = TestbenchIO(Adapter(i=layout, o=layout))
+            tgt = TestbenchIO(Adapter.create(i=layout, o=layout))
             methods.append(tgt.adapter.iface)
             self.target.append(tgt)
             m.submodules += tgt

--- a/test/test_methods.py
+++ b/test/test_methods.py
@@ -407,7 +407,7 @@ class ConditionalCallCircuit(Elaboratable):
         meth = Method(i=data_layout(1))
 
         m.submodules.tb = self.tb = TestbenchIO(AdapterTrans(meth))
-        m.submodules.out = self.out = TestbenchIO(Adapter())
+        m.submodules.out = self.out = TestbenchIO(Adapter.create())
 
         @def_method(m, meth)
         def _(arg):
@@ -456,7 +456,7 @@ class ConditionalTransactionCircuit1(Elaboratable):
         m = TModule()
 
         self.ready = Signal()
-        m.submodules.tb = self.tb = TestbenchIO(Adapter())
+        m.submodules.tb = self.tb = TestbenchIO(Adapter.create())
 
         with Transaction().body(m, request=self.ready):
             self.tb.adapter.iface(m)
@@ -469,7 +469,7 @@ class ConditionalTransactionCircuit2(Elaboratable):
         m = TModule()
 
         self.ready = Signal()
-        m.submodules.tb = self.tb = TestbenchIO(Adapter())
+        m.submodules.tb = self.tb = TestbenchIO(Adapter.create())
 
         with m.If(self.ready):
             with Transaction().body(m):

--- a/test/test_methods.py
+++ b/test/test_methods.py
@@ -538,9 +538,9 @@ class NonexclusiveMethodCircuit(Elaboratable):
         self.running = Signal()
         self.data = Signal(WIDTH)
 
-        method = Method(o=data_layout(WIDTH), nonexclusive=True)
+        method = Method(o=data_layout(WIDTH))
 
-        @def_method(m, method, self.ready)
+        @def_method(m, method, self.ready, nonexclusive=True)
         def _():
             m.d.comb += self.running.eq(1)
             return {"data": self.data}
@@ -594,20 +594,20 @@ class TwoNonexclusiveConflictCircuit(Elaboratable):
         self.running1 = Signal()
         self.running2 = Signal()
 
-        method1 = Method(o=data_layout(WIDTH), nonexclusive=True)
-        method2 = Method(o=data_layout(WIDTH), nonexclusive=self.two_nonexclusive)
+        method1 = Method(o=data_layout(WIDTH))
+        method2 = Method(o=data_layout(WIDTH))
         method_in = Method(o=data_layout(WIDTH))
 
         @def_method(m, method_in)
         def _():
             return {"data": 0}
 
-        @def_method(m, method1)
+        @def_method(m, method1, nonexclusive=True)
         def _():
             m.d.comb += self.running1.eq(1)
             return method_in(m)
 
-        @def_method(m, method2)
+        @def_method(m, method2, nonexclusive=self.two_nonexclusive)
         def _():
             m.d.comb += self.running2.eq(1)
             return method_in(m)
@@ -649,9 +649,9 @@ class CustomCombinerMethodCircuit(Elaboratable):
                 result = result ^ Mux(runs[i], v.data, 0)
             return {"data": result}
 
-        method = Method(i=data_layout(WIDTH), o=data_layout(WIDTH), nonexclusive=True, combiner=combiner)
+        method = Method(i=data_layout(WIDTH), o=data_layout(WIDTH))
 
-        @def_method(m, method, self.ready)
+        @def_method(m, method, self.ready, nonexclusive=True, combiner=combiner)
         def _(data: Value):
             m.d.comb += self.running.eq(1)
             return {"data": data}

--- a/test/test_simultaneous.py
+++ b/test/test_simultaneous.py
@@ -140,7 +140,7 @@ class TransitivityTestCircuit(Elaboratable):
 
 class TestTransitivity(TestCaseWithSimulator):
     def test_transitivity(self):
-        target = TestbenchIO(Adapter(i=[("data", 2)]))
+        target = TestbenchIO(Adapter.create(i=[("data", 2)]))
         req1 = Signal()
         req2 = Signal()
 

--- a/test/testing/test_validate_arguments.py
+++ b/test/testing/test_validate_arguments.py
@@ -14,7 +14,7 @@ class ValidateArgumentsTestCircuit(Elaboratable):
     def elaborate(self, platform):
         m = Module()
 
-        self.method = TestbenchIO(Adapter(i=data_layout(1), o=data_layout(1)).set(with_validate_arguments=True))
+        self.method = TestbenchIO(Adapter.create(i=data_layout(1), o=data_layout(1)).set(with_validate_arguments=True))
         self.caller1 = TestbenchIO(AdapterTrans(self.method.adapter.iface))
         self.caller2 = TestbenchIO(AdapterTrans(self.method.adapter.iface))
 

--- a/transactron/core/__init__.py
+++ b/transactron/core/__init__.py
@@ -4,3 +4,4 @@ from .method import *  # noqa: F401
 from .transaction import *  # noqa: F401
 from .manager import *  # noqa: F401
 from .sugar import *  # noqa: F401
+from .body import *  # noqa: F401

--- a/transactron/core/body.py
+++ b/transactron/core/body.py
@@ -51,6 +51,7 @@ class Body(OwnedAndNamed):
         self.name = name
         self.owner = owner
         self.ready = Signal(name=self.owned_name + "_ready")
+        self.runnable = Signal(name=self.owned_name + "_runnable")
         self.run = Signal(name=self.owned_name + "_run")
         self.data_in: MethodStruct = Signal(from_method_layout(i), name=self.owned_name + "_data_in")
         self.data_out: MethodStruct = Signal(from_method_layout(o), name=self.owned_name + "_data_out")

--- a/transactron/core/body.py
+++ b/transactron/core/body.py
@@ -1,0 +1,61 @@
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+
+from amaranth.lib.data import StructLayout
+from transactron.core.tmodule import TModule
+from transactron.graph import Owned
+
+from transactron.utils import *
+from amaranth import *
+from typing import ClassVar, Optional, Callable, Protocol, final
+from .transaction_base import *
+from transactron.utils.assign import AssignArg
+
+
+__all__ = ["Body"]
+
+
+@final
+class Body(TransactionBase):
+    stack: ClassVar[list["Body"]] = []
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        owner: Optional[Elaboratable],
+        i: StructLayout,
+        o: StructLayout,
+        combiner: Optional[Callable[[Module, Sequence[MethodStruct], Value], AssignArg]],
+        validate_arguments: Optional[Callable[..., ValueLike]],
+        nonexclusive: bool,
+        single_caller: bool,
+        src_loc: SrcLoc
+    ):
+        super().__init__(src_loc=src_loc)
+        
+        def default_combiner(m: Module, args: Sequence[MethodStruct], runs: Value) -> AssignArg:
+            ret = Signal(from_method_layout(i))
+            for k in OneHotSwitchDynamic(m, runs):
+                m.d.comb += ret.eq(args[k])
+            return ret
+
+        self.def_order = next(TransactionBase.def_counter)
+        self.name = name
+        self.owner = owner
+        self.ready = Signal(name=self.owned_name + "_ready")
+        self.run = Signal(name=self.owned_name + "_run")
+        self.data_in: MethodStruct = Signal(from_method_layout(i), name=self.owned_name + "_data_in")
+        self.data_out: MethodStruct = Signal(from_method_layout(o), name=self.owned_name + "_data_out")
+        self.combiner: Callable[[Module, Sequence[MethodStruct], Value], AssignArg] = combiner or default_combiner
+        self.nonexclusive = nonexclusive
+        self.single_caller = single_caller
+        self.validate_arguments: Optional[Callable[..., ValueLike]] = validate_arguments
+        
+        if nonexclusive:
+            assert len(self.data_in.as_value()) == 0 or combiner is not None
+    
+    def _validate_arguments(self, arg_rec: MethodStruct) -> ValueLike:
+        if self.validate_arguments is not None:
+            return self.ready & method_def_helper(self, self.validate_arguments, arg_rec)
+        return self.ready

--- a/transactron/core/manager.py
+++ b/transactron/core/manager.py
@@ -14,10 +14,9 @@ from transactron.utils import *
 from transactron.utils.transactron_helpers import _graph_ccs
 from transactron.graph import OwnershipGraph, Direction
 
-from .transaction_base import Priority
+from .transaction_base import Priority, Relation, TransactionBase
 from .body import Body, TBody, MBody
 from .transaction import Transaction, TransactionManagerKey
-from .method import Method
 from .tmodule import TModule
 from .schedulers import eager_deterministic_cc_scheduler
 
@@ -86,14 +85,14 @@ class TransactionManager(Elaboratable):
 
     def __init__(self, cc_scheduler: TransactionScheduler = eager_deterministic_cc_scheduler):
         self.transactions: list[Transaction] = []
-        self.methods: list[Method] = []
+        self.relations: list[Relation[TransactionBase | Body]] = []
         self.cc_scheduler = cc_scheduler
 
-    def add_transaction(self, transaction: Transaction):
+    def _add_transaction(self, transaction: Transaction):
         self.transactions.append(transaction)
 
-    def add_method(self, method: Method):
-        self.methods.append(method)
+    def _add_relation(self, relation: Relation):
+        self.relations.append(relation)
 
     @staticmethod
     def _conflict_graph(method_map: MethodMap) -> tuple[TransactionGraph, PriorityOrder]:
@@ -172,7 +171,6 @@ class TransactionManager(Elaboratable):
                         add_edge(transaction1, transaction2, Priority.UNDEFINED, True)
 
         relations = [
-            # TODO
             #            Relation(**relation, start=elem)
             #            for elem in method_map.methods_and_transactions
             #            for relation in elem.relations

--- a/transactron/core/manager.py
+++ b/transactron/core/manager.py
@@ -340,10 +340,10 @@ class TransactionManager(Elaboratable):
         for elem in method_map.methods_and_transactions:
             elem._set_method_uses(m)
 
-        for transaction in self.transactions:
+        for transaction in method_map.transactions:
             ready = [
-                method._validate_arguments(method_map.argument_by_call[transaction._body, method])
-                for method in method_map.methods_by_transaction[transaction._body]
+                method._validate_arguments(method_map.argument_by_call[transaction, method])
+                for method in method_map.methods_by_transaction[transaction]
             ]
             m.d.comb += transaction.runnable.eq(Cat(ready).all())
 

--- a/transactron/core/manager.py
+++ b/transactron/core/manager.py
@@ -40,7 +40,7 @@ class MethodMap:
         def rec(transaction: TBody, source: Body, ancestors: tuple[MBody, ...]):
             for method_obj, (arg_rec, _) in source.method_uses.items():
                 method = MBody(method_obj._body)
-                if method_obj in self.methods_by_transaction[transaction]:
+                if method in self.methods_by_transaction[transaction]:
                     raise RuntimeError(f"Method '{method_obj.name}' can't be called twice from the same transaction")
                 self.methods_by_transaction[transaction].append(method)
                 self.transactions_by_method[method].append(transaction)

--- a/transactron/core/manager.py
+++ b/transactron/core/manager.py
@@ -305,11 +305,13 @@ class TransactionManager(Elaboratable):
             methods[transaction] = method
 
         # step 5: construct merged transactions
-        for group in final_simultaneous:
-            name = "_".join([t.name for t in group])
-            with Transaction(name=name).body(m):
-                for transaction in group:
-                    methods[transaction](m)
+        with DependencyContext(DependencyManager()):
+            DependencyContext.get().add_dependency(TransactionManagerKey(), self)
+            for group in final_simultaneous:
+                name = "_".join([t.name for t in group])
+                with Transaction(name=name).body(m):
+                    for transaction in group:
+                        methods[transaction](m)
 
         return m
 

--- a/transactron/core/method.py
+++ b/transactron/core/method.py
@@ -76,21 +76,6 @@ class Method(TransactionBase["Transaction | Method"]):
             The format of `data_in`.
         o: method layout
             The format of `data_out`.
-        nonexclusive: bool
-            If true, the method is non-exclusive: it can be called by multiple
-            transactions in the same clock cycle. If such a situation happens,
-            the method still is executed only once, and each of the callers
-            receive its output. Nonexclusive methods cannot have inputs.
-        combiner: (Module, Sequence[MethodStruct], Value) -> AssignArg
-            If `nonexclusive` is true, the combiner function combines the
-            arguments from multiple calls to this method into a single
-            argument, which is passed to the method body. The third argument
-            is a bit vector, whose n-th bit is 1 if the n-th call is active
-            in a given cycle.
-        single_caller: bool
-            If true, this method is intended to be called from a single
-            transaction. An error will be thrown if called from multiple
-            transactions.
         src_loc: int | SrcLoc
             How many stack frames deep the source location is taken from.
             Alternatively, the source location to use instead of the default.
@@ -207,6 +192,21 @@ class Method(TransactionBase["Transaction | Method"]):
             It instantiates a combinational circuit for each
             method caller. By default, there is no function, so all arguments
             are accepted.
+        combiner: (Module, Sequence[MethodStruct], Value) -> AssignArg
+            If `nonexclusive` is true, the combiner function combines the
+            arguments from multiple calls to this method into a single
+            argument, which is passed to the method body. The third argument
+            is a bit vector, whose n-th bit is 1 if the n-th call is active
+            in a given cycle.
+        nonexclusive: bool
+            If true, the method is non-exclusive: it can be called by multiple
+            transactions in the same clock cycle. If such a situation happens,
+            the method still is executed only once, and each of the callers
+            receive its output. Nonexclusive methods cannot have inputs.
+        single_caller: bool
+            If true, this method is intended to be called from a single
+            transaction. An error will be thrown if called from multiple
+            transactions.
 
         Returns
         -------

--- a/transactron/core/method.py
+++ b/transactron/core/method.py
@@ -3,13 +3,13 @@ from collections.abc import Sequence
 from transactron.utils import *
 from amaranth import *
 from amaranth import tracer
-from typing import TYPE_CHECKING, Optional, Callable, Iterator
+from typing import TYPE_CHECKING, Optional, Iterator, Unpack
 from .transaction_base import *
 from contextlib import contextmanager
 from transactron.utils.assign import AssignArg
 from transactron.utils._typing import type_self_add_1pos_kwargs_as
 
-from .body import Body, MBody
+from .body import Body, BodyParams, MBody
 from .keys import TransactionManagerKey
 from .tmodule import TModule
 from .transaction_base import TransactionBase
@@ -154,15 +154,7 @@ class Method(TransactionBase["Transaction | Method"]):
 
     @contextmanager
     def body(
-        self,
-        m: TModule,
-        *,
-        ready: ValueLike = C(1),
-        out: ValueLike = C(0, 0),
-        validate_arguments: Optional[Callable[..., ValueLike]] = None,
-        combiner: Optional[Callable[[Module, Sequence[MethodStruct], Value], AssignArg]] = None,
-        nonexclusive: bool = False,
-        single_caller: bool = False,
+        self, m: TModule, *, ready: ValueLike = C(1), out: ValueLike = C(0, 0), **kwargs: Unpack[BodyParams]
     ) -> Iterator[MethodStruct]:
         """Define method body
 
@@ -226,15 +218,7 @@ class Method(TransactionBase["Transaction | Method"]):
                 m.d.comb += sum.eq(data_in.arg1 + data_in.arg2)
         """
         body = Body(
-            name=self.name,
-            owner=self.owner,
-            i=self.layout_in,
-            o=self.layout_out,
-            combiner=combiner,
-            validate_arguments=validate_arguments,
-            nonexclusive=nonexclusive,
-            single_caller=single_caller,
-            src_loc=self.src_loc,
+            name=self.name, owner=self.owner, i=self.layout_in, o=self.layout_out, src_loc=self.src_loc, **kwargs
         )
         self._set_impl(m, body)
 

--- a/transactron/core/method.py
+++ b/transactron/core/method.py
@@ -144,6 +144,8 @@ class Method(TransactionBase["Transaction | Method"]):
     def _set_impl(self, m: TModule, value: "Body | Method"):
         if self._body_ptr is not None:
             raise RuntimeError(f"Method '{self.name}' already defined")
+        if value.data_in.shape() != self.layout_in or value.data_out.shape() != self.layout_out:
+            raise ValueError(f"Method {value.name} has different interface than {self.name}")
         self._body_ptr = value
         m.d.comb += self.ready.eq(value.ready)
         m.d.comb += self.run.eq(value.run)

--- a/transactron/core/method.py
+++ b/transactron/core/method.py
@@ -10,7 +10,6 @@ from transactron.utils.assign import AssignArg
 from transactron.utils._typing import type_self_add_1pos_kwargs_as
 
 from .body import Body, MBody
-from .keys import TransactionManagerKey
 from .tmodule import TModule
 from .transaction_base import TransactionBase
 
@@ -237,9 +236,6 @@ class Method(TransactionBase):
         with body.context(m):
             with m.AvoidedIf(body.run):
                 yield body.data_in
-
-        manager = DependencyContext.get().get_dependency(TransactionManagerKey())
-        manager.add_method(self)
 
     def __call__(
         self, m: TModule, arg: Optional[AssignArg] = None, enable: ValueLike = C(1), /, **kwargs: AssignArg

--- a/transactron/core/method.py
+++ b/transactron/core/method.py
@@ -9,16 +9,16 @@ from contextlib import contextmanager
 from transactron.utils.assign import AssignArg
 from transactron.utils._typing import type_self_add_1pos_kwargs_as
 
-from ..graph import Owned
 from .body import Body, MBody
 from .keys import TransactionManagerKey
 from .tmodule import TModule
+from .transaction_base import TransactionBase
 
 
 __all__ = ["Method", "Methods"]
 
 
-class Method(Owned):
+class Method(TransactionBase):
     """Transactional method.
 
     A `Method` serves to interface a module with external `Transaction`\\s
@@ -91,13 +91,13 @@ class Method(Owned):
             How many stack frames deep the source location is taken from.
             Alternatively, the source location to use instead of the default.
         """
+        super().__init__(src_loc=get_src_loc(src_loc))
         self.owner, owner_name = get_caller_class_name(default="$method")
         self.name = name or tracer.get_var_name(depth=2, default=owner_name)
         self.ready = Signal(name=self.owned_name + "_ready")
         self.run = Signal(name=self.owned_name + "_run")
         self.data_in: MethodStruct = Signal(from_method_layout(i), name=self.owned_name + "_data_in")
         self.data_out: MethodStruct = Signal(from_method_layout(o), name=self.owned_name + "_data_out")
-        self.src_loc = get_src_loc(src_loc)
 
     @property
     def layout_in(self):

--- a/transactron/core/schedulers.py
+++ b/transactron/core/schedulers.py
@@ -72,6 +72,6 @@ def trivial_roundrobin_cc_scheduler(
     sched = Scheduler(len(cc))
     m.submodules.scheduler = sched
     for k, transaction in enumerate(cc):
-        m.d.comb += sched.requests[k].eq(transaction.request & transaction.runnable)
-        m.d.comb += transaction.grant.eq(sched.grant[k] & sched.valid)
+        m.d.comb += sched.requests[k].eq(transaction.ready & transaction.runnable)
+        m.d.comb += transaction.run.eq(sched.grant[k] & sched.valid)
     return m

--- a/transactron/core/schedulers.py
+++ b/transactron/core/schedulers.py
@@ -38,9 +38,9 @@ def eager_deterministic_cc_scheduler(
     ccl = list(cc)
     ccl.sort(key=lambda transaction: porder[transaction])
     for k, transaction in enumerate(ccl):
-        conflicts = [ccl[j].grant for j in range(k) if ccl[j] in gr[transaction]]
+        conflicts = [ccl[j].run for j in range(k) if ccl[j] in gr[transaction]]
         noconflict = ~Cat(conflicts).any()
-        m.d.comb += transaction.grant.eq(transaction.request & transaction.runnable & noconflict)
+        m.d.comb += transaction.run.eq(transaction.ready & transaction.runnable & noconflict)
     return m
 
 

--- a/transactron/core/sugar.py
+++ b/transactron/core/sugar.py
@@ -1,13 +1,11 @@
 from collections.abc import Sequence, Callable
 from amaranth import *
-from typing import TYPE_CHECKING, Optional, Concatenate, ParamSpec
+from typing import Optional, Concatenate, ParamSpec
 from transactron.utils import *
 from transactron.utils.assign import AssignArg
 from functools import partial
-
-if TYPE_CHECKING:
-    from .tmodule import TModule
-    from .method import Method
+from .tmodule import TModule
+from .method import Method
 
 __all__ = ["def_method", "def_methods"]
 
@@ -16,10 +14,13 @@ P = ParamSpec("P")
 
 
 def def_method(
-    m: "TModule",
-    method: "Method",
+    m: TModule,
+    method: Method,
     ready: ValueLike = C(1),
+    combiner: Optional[Callable[[Module, Sequence[MethodStruct], Value], AssignArg]] = None,
     validate_arguments: Optional[Callable[..., ValueLike]] = None,
+    nonexclusive: bool = False,
+    single_caller: bool = False,
 ):
     """Define a method.
 
@@ -86,7 +87,7 @@ def def_method(
         out = Signal(method.layout_out)
         ret_out = None
 
-        with method.body(m, ready=ready, out=out, validate_arguments=validate_arguments) as arg:
+        with method.body(m, ready=ready, out=out, combiner=combiner, validate_arguments=validate_arguments, nonexclusive=nonexclusive, single_caller=single_caller) as arg:
             ret_out = method_def_helper(method, func, arg)
 
         if ret_out is not None:
@@ -96,8 +97,8 @@ def def_method(
 
 
 def def_methods(
-    m: "TModule",
-    methods: Sequence["Method"],
+    m: TModule,
+    methods: Sequence[Method],
     ready: Callable[[int], ValueLike] = lambda _: C(1),
     validate_arguments: Optional[Callable[..., ValueLike]] = None,
 ):

--- a/transactron/core/sugar.py
+++ b/transactron/core/sugar.py
@@ -47,11 +47,15 @@ def def_method(
         default it is `Const(1)`, so the method is always ready.
         Assigned combinationally to the `ready` attribute.
     validate_arguments: Optional[Callable[..., ValueLike]]
-        Function that takes input arguments used to call the method
-        and checks whether the method can be called with those arguments.
-        It instantiates a combinational circuit for each
-        method caller. By default, there is no function, so all arguments
-        are accepted.
+        For details, see `Method.body`.
+    validate_arguments: Optional[Callable[..., ValueLike]]
+        For details, see `Method.body`.
+    combiner: (Module, Sequence[MethodStruct], Value) -> AssignArg
+        For details, see `Method.body`.
+    nonexclusive: bool
+        For details, see `Method.body`.
+    single_caller: bool
+        For details, see `Method.body`.
 
     Examples
     --------

--- a/transactron/core/sugar.py
+++ b/transactron/core/sugar.py
@@ -87,7 +87,15 @@ def def_method(
         out = Signal(method.layout_out)
         ret_out = None
 
-        with method.body(m, ready=ready, out=out, combiner=combiner, validate_arguments=validate_arguments, nonexclusive=nonexclusive, single_caller=single_caller) as arg:
+        with method.body(
+            m,
+            ready=ready,
+            out=out,
+            combiner=combiner,
+            validate_arguments=validate_arguments,
+            nonexclusive=nonexclusive,
+            single_caller=single_caller,
+        ) as arg:
             ret_out = method_def_helper(method, func, arg)
 
         if ret_out is not None:

--- a/transactron/core/transaction.py
+++ b/transactron/core/transaction.py
@@ -94,6 +94,7 @@ class Transaction(OwnedAndNamed):
             raise RuntimeError(f"Transaction '{self.name}' already defined")
         self._body_ptr = value
         m.d.comb += self.request.eq(value.ready)
+        m.d.comb += self.runnable.eq(value.runnable)
         m.d.comb += self.grant.eq(value.run)
 
     @contextmanager

--- a/transactron/core/transaction.py
+++ b/transactron/core/transaction.py
@@ -120,10 +120,6 @@ class Transaction(TransactionBase["Transaction | Method"]):
             owner=self.owner,
             i=StructLayout({}),
             o=StructLayout({}),
-            combiner=None,
-            validate_arguments=None,
-            nonexclusive=False,
-            single_caller=False,
             src_loc=self.src_loc,
         )
         self._set_impl(m, impl)

--- a/transactron/core/transaction.py
+++ b/transactron/core/transaction.py
@@ -88,6 +88,8 @@ class Transaction(TransactionBase["Transaction | Method"]):
     def _set_impl(self, m: TModule, value: Body):
         if self._body_ptr is not None:
             raise RuntimeError(f"Transaction '{self.name}' already defined")
+        if value.data_in.shape().size != 0 or value.data_out.shape().size != 0:
+            raise ValueError(f"Transaction body {value.name} has invalid interface")
         self._body_ptr = value
         m.d.comb += self.request.eq(value.ready)
         m.d.comb += self.runnable.eq(value.runnable)

--- a/transactron/core/transaction.py
+++ b/transactron/core/transaction.py
@@ -3,17 +3,17 @@ from transactron.utils import *
 from amaranth import *
 from amaranth import tracer
 from typing import Optional, Iterator
-from ..graph import Owned
 from .keys import *
 from contextlib import contextmanager
 from .body import Body, TBody
 from .tmodule import TModule
+from .transaction_base import TransactionBase
 
 
 __all__ = ["Transaction"]
 
 
-class Transaction(Owned):
+class Transaction(TransactionBase):
     """Transaction.
 
     A `Transaction` represents a task which needs to be regularly done.
@@ -66,6 +66,7 @@ class Transaction(Owned):
             How many stack frames deep the source location is taken from.
             Alternatively, the source location to use instead of the default.
         """
+        super().__init__(src_loc=get_src_loc(src_loc))
         self.owner, owner_name = get_caller_class_name(default="$transaction")
         self.name = name or tracer.get_var_name(depth=2, default=owner_name)
         manager = DependencyContext.get().get_dependency(TransactionManagerKey())
@@ -73,7 +74,6 @@ class Transaction(Owned):
         self.request = Signal(name=self.owned_name + "_request")
         self.runnable = Signal(name=self.owned_name + "_runnable")
         self.grant = Signal(name=self.owned_name + "_grant")
-        self.src_loc = get_src_loc(src_loc)
 
     @property
     def _body(self) -> TBody:

--- a/transactron/core/transaction.py
+++ b/transactron/core/transaction.py
@@ -70,7 +70,7 @@ class Transaction(TransactionBase):
         self.owner, owner_name = get_caller_class_name(default="$transaction")
         self.name = name or tracer.get_var_name(depth=2, default=owner_name)
         manager = DependencyContext.get().get_dependency(TransactionManagerKey())
-        manager.add_transaction(self)
+        manager._add_transaction(self)
         self.request = Signal(name=self.owned_name + "_request")
         self.runnable = Signal(name=self.owned_name + "_runnable")
         self.grant = Signal(name=self.owned_name + "_grant")

--- a/transactron/core/transaction.py
+++ b/transactron/core/transaction.py
@@ -2,7 +2,7 @@ from amaranth.lib.data import StructLayout
 from transactron.utils import *
 from amaranth import *
 from amaranth import tracer
-from typing import Optional, Iterator
+from typing import TYPE_CHECKING, Optional, Iterator
 from .keys import *
 from contextlib import contextmanager
 from .body import Body, TBody
@@ -10,10 +10,14 @@ from .tmodule import TModule
 from .transaction_base import TransactionBase
 
 
+if TYPE_CHECKING:
+    from .method import Method  # noqa: F401
+
+
 __all__ = ["Transaction"]
 
 
-class Transaction(TransactionBase):
+class Transaction(TransactionBase["Transaction | Method"]):
     """Transaction.
 
     A `Transaction` represents a task which needs to be regularly done.

--- a/transactron/core/transaction_base.py
+++ b/transactron/core/transaction_base.py
@@ -1,28 +1,20 @@
-from collections import defaultdict
-from collections.abc import Iterator
-from contextlib import contextmanager
 from enum import Enum, auto
-from itertools import count
 from typing import (
-    ClassVar,
     TypeAlias,
     TypedDict,
     Union,
     TypeVar,
     Protocol,
-    Self,
     runtime_checkable,
     TYPE_CHECKING,
-    Optional,
 )
 from amaranth import *
 
-from .tmodule import TModule, CtrlPath
 from transactron.graph import Owned
 from transactron.utils import *
+from .body import Body
 
 if TYPE_CHECKING:
-    from .method import Body, Method
     from .transaction import Transaction
 
 __all__ = ["TransactionBase", "Priority"]
@@ -51,21 +43,8 @@ class Relation(RelationBase):
     start: TransactionOrMethodImpl
 
 
-class OwnedAndNamed(Owned, Protocol):
-    name: str
-
-    @property
-    def owned_name(self):
-        if self.owner is not None and self.owner.__class__.__name__ != self.name:
-            return f"{self.owner.__class__.__name__}_{self.name}"
-        else:
-            return self.name
-
-
 @runtime_checkable
-class TransactionBase(OwnedAndNamed, Protocol):
-    def_counter: ClassVar[count] = count()
-    def_order: int
+class TransactionBase(Owned, Protocol):
     defined: bool = False
     src_loc: SrcLoc
     relations: list[RelationBase]

--- a/transactron/graph.py
+++ b/transactron/graph.py
@@ -14,6 +14,13 @@ class Owned(Protocol):
     name: str
     owner: Optional[Elaboratable]
 
+    @property
+    def owned_name(self):
+        if self.owner is not None and self.owner.__class__.__name__ != self.name:
+            return f"{self.owner.__class__.__name__}_{self.name}"
+        else:
+            return self.name
+
 
 class Direction(IntFlag):
     NONE = 0

--- a/transactron/lib/fifo.py
+++ b/transactron/lib/fifo.py
@@ -179,7 +179,7 @@ class WideFifo(Elaboratable):
         self.depth = depth
 
         self.read = Method(i=[("count", range(read_width + 1))], o=self.read_layout, src_loc=src_loc)
-        self.peek = Method(o=self.read_layout, nonexclusive=True, src_loc=src_loc)
+        self.peek = Method(o=self.read_layout, src_loc=src_loc)
         self.write = Method(i=self.write_layout, src_loc=src_loc)
         self.clear = Method(src_loc=src_loc)
 
@@ -275,7 +275,7 @@ class WideFifo(Elaboratable):
             m.d.comb += incr_row_col(next_read_row, next_read_col, read_row, read_col, incr_read_row, read_count)
             return {"count": read_count, "data": head}
 
-        @def_method(m, self.peek, level != 0)
+        @def_method(m, self.peek, level != 0, nonexclusive=True)
         def _():
             return {"count": read_available, "data": head}
 

--- a/transactron/lib/fifo.py
+++ b/transactron/lib/fifo.py
@@ -51,7 +51,7 @@ class BasicFifo(Elaboratable):
 
         src_loc = get_src_loc(src_loc)
         self.read = Method(o=self.layout, src_loc=src_loc)
-        self.peek = Method(o=self.layout, nonexclusive=True, src_loc=src_loc)
+        self.peek = Method(o=self.layout, src_loc=src_loc)
         self.write = Method(i=self.layout, src_loc=src_loc)
         self.clear = Method(src_loc=src_loc)
         self.head = Signal(from_method_layout(layout))
@@ -106,7 +106,7 @@ class BasicFifo(Elaboratable):
             m.d.sync += self.read_idx.eq(next_read_idx)
             return self.head
 
-        @def_method(m, self.peek, self.read_ready)
+        @def_method(m, self.peek, self.read_ready, nonexclusive=True)
         def _() -> ValueLike:
             return self.head
 

--- a/transactron/lib/reqres.py
+++ b/transactron/lib/reqres.py
@@ -67,7 +67,7 @@ class ArgumentsToResultsZipper(Elaboratable):
         self.args_layout = args_layout
         self.output_layout = [("args", self.args_layout), ("results", results_layout)]
 
-        self.peek_arg = Method(o=self.args_layout, nonexclusive=True, src_loc=self.src_loc)
+        self.peek_arg = Method(o=self.args_layout, src_loc=self.src_loc)
         self.write_args = Method(i=self.args_layout, src_loc=self.src_loc)
         self.write_results = Method(i=self.results_layout, src_loc=self.src_loc)
         self.read = Method(o=self.output_layout, src_loc=self.src_loc)

--- a/transactron/lib/simultaneous.py
+++ b/transactron/lib/simultaneous.py
@@ -56,7 +56,7 @@ def condition(m: TModule, *, nonblocking: bool = False, priority: bool = False):
                 ...
     """
     this = Body.get()
-    transactions = list[Transaction]()
+    transactions = list[Body]()
     last = False
     conds = list[Signal]()
 
@@ -72,10 +72,10 @@ def condition(m: TModule, *, nonblocking: bool = False, priority: bool = False):
         with (transaction := Transaction(name=name, src_loc=src_loc)).body(m, request=req):
             yield
         if transactions and priority:
-            transactions[-1].schedule_before(transaction)
+            transactions[-1].schedule_before(transaction._body)
         if cond is None:
             last = True
-        transactions.append(transaction)
+        transactions.append(transaction._body)
 
     yield branch
 

--- a/transactron/lib/simultaneous.py
+++ b/transactron/lib/simultaneous.py
@@ -1,8 +1,7 @@
 from amaranth import *
 
 from ..utils import SrcLoc
-from ..core import *
-from ..core import TransactionBase
+from ..core import TModule, Transaction, Body
 from contextlib import contextmanager
 from typing import Optional
 from transactron.utils import ValueLike
@@ -56,7 +55,7 @@ def condition(m: TModule, *, nonblocking: bool = False, priority: bool = False):
             with branch():  # default, optional
                 ...
     """
-    this = TransactionBase.get()
+    this = Body.get()
     transactions = list[Transaction]()
     last = False
     conds = list[Signal]()

--- a/transactron/lib/transformers.py
+++ b/transactron/lib/transformers.py
@@ -177,7 +177,7 @@ class MethodFilter(Elaboratable, Transformer):
         self.target = target
         self.use_condition = use_condition
         src_loc = get_src_loc(src_loc)
-        self.method = Method(i=target.layout_in, o=target.layout_out, single_caller=self.use_condition, src_loc=src_loc)
+        self.method = Method(i=target.layout_in, o=target.layout_out, src_loc=src_loc)
         self.condition = condition
         self.default = default
 
@@ -189,7 +189,7 @@ class MethodFilter(Elaboratable, Transformer):
         ret = Signal.like(self.target.data_out)
         m.d.comb += assign(ret, self.default, fields=AssignType.ALL)
 
-        @def_method(m, self.method)
+        @def_method(m, self.method, single_caller=self.use_condition)
         def _(arg):
             if self.use_condition:
                 cond = Signal()

--- a/transactron/testing/profiler.py
+++ b/transactron/testing/profiler.py
@@ -20,7 +20,7 @@ def profiler_process(transaction_manager: TransactionManager, profile: Profile):
             sim.tick()
             .sample(
                 *(
-                    View(transaction_sample_layout, Cat(transaction.request, transaction.runnable, transaction.grant))
+                    View(transaction_sample_layout, Cat(transaction.ready, transaction.runnable, transaction.run))
                     for transaction in method_map.transactions
                 )
             )

--- a/transactron/utils/gen.py
+++ b/transactron/utils/gen.py
@@ -193,9 +193,9 @@ def collect_transaction_method_signals(
     get_id = IdGenerator()
 
     for transaction in method_map.transactions:
-        request_loc = get_signal_location(transaction.request, name_map)
+        request_loc = get_signal_location(transaction.ready, name_map)
         runnable_loc = get_signal_location(transaction.runnable, name_map)
-        grant_loc = get_signal_location(transaction.grant, name_map)
+        grant_loc = get_signal_location(transaction.run, name_map)
         transaction_signals_location[get_id(transaction)] = TransactionSignalsLocation(
             request_loc, runnable_loc, grant_loc
         )

--- a/transactron/utils/transactron_helpers.py
+++ b/transactron/utils/transactron_helpers.py
@@ -9,6 +9,7 @@ from amaranth import *
 from amaranth import tracer
 from amaranth.lib.data import StructLayout
 import amaranth.lib.data as data
+import dataclasses
 
 
 __all__ = [
@@ -23,6 +24,7 @@ __all__ = [
     "from_method_layout",
     "make_layout",
     "extend_layout",
+    "dataclass_asdict",
 ]
 
 T = TypeVar("T")
@@ -167,3 +169,9 @@ def from_method_layout(layout: MethodLayout) -> StructLayout:
         return layout
     else:
         return StructLayout({k: from_layout_field(v) for k, v in layout})
+
+
+def dataclass_asdict(obj: Any) -> dict[str, Any]:
+    # Workaround for dataclass.asdict calling deepcopy without a reason, see:
+    # https://github.com/python/cpython/issues/88071
+    return {field.name: getattr(obj, field.name) for field in dataclasses.fields(obj)}


### PR DESCRIPTION
This PR introduces the following changes:

* Both `Transaction` and `Method` have an internal implementation of type `Body`.
* Multiple `Method` objects can refer to the same `Body`. This is used in the new implementation of `proxy`.
* Transaction to method transformation in simultaneous transactions now reuses the internal `Body` - no magic needed.
* Several implementation-related parameters moved from `Method.__init__` to `Method.body`. This makes `proxy` less weird - the proxy will always be like the target method.
* Also, the parameters are now stored using a `TypedDict`. This allowed to take care of some repetitive code.
* As a consequence, modules which require a method from the environment can declare them in the attributes, and then receive implementations via `proxy`.

TODO:
* [x] Take care of warnings.
* [x] Update documentation.
* [x] Fix types.
* [x] Check if Coreblocks tests pass.
* [x] Check if profiles and graphs still work.