### PR TITLE
Fix priority encoder after #29

### DIFF
--- a/test/utils/amaranth_ext/test_coding.py
+++ b/test/utils/amaranth_ext/test_coding.py
@@ -1,0 +1,79 @@
+# This module was copied from Amaranth because it is deprecated there.
+# Copyright (C) 2019-2024 Amaranth HDL contributors
+
+from amaranth.hdl import *
+from amaranth.sim import *
+from transactron.utils.amaranth_ext.coding import *
+from transactron.testing import *
+
+
+class TestEncoder(TestCaseWithSimulator):
+    def test_basic(self):
+        enc = Encoder(4)
+
+        async def process(sim: TestbenchContext):
+            assert sim.get(enc.n) == 1
+            assert sim.get(enc.o) == 0
+
+            sim.set(enc.i, 0b0001)
+            assert sim.get(enc.n) == 0
+            assert sim.get(enc.o) == 0
+
+            sim.set(enc.i, 0b0100)
+            assert sim.get(enc.n) == 0
+            assert sim.get(enc.o) == 2
+
+            sim.set(enc.i, 0b0110)
+            assert sim.get(enc.n) == 1
+            assert sim.get(enc.o) == 0
+
+        with self.run_simulation(enc) as sim:
+            sim.add_testbench(process)
+
+
+class TestPriorityEncoder(TestCaseWithSimulator):
+    def test_basic(self):
+        enc = PriorityEncoder(4)
+
+        async def process(sim: TestbenchContext):
+            assert sim.get(enc.n) == 1
+            assert sim.get(enc.o) == 0
+
+            sim.set(enc.i, 0b0001)
+            assert sim.get(enc.n) == 0
+            assert sim.get(enc.o) == 0
+
+            sim.set(enc.i, 0b0100)
+            assert sim.get(enc.n) == 0
+            assert sim.get(enc.o) == 2
+
+            sim.set(enc.i, 0b0110)
+            assert sim.get(enc.n) == 0
+            assert sim.get(enc.o) == 1
+
+            sim.set(enc.i, 0b1110)
+            assert sim.get(enc.n) == 0
+            assert sim.get(enc.o) == 1
+
+        with self.run_simulation(enc) as sim:
+            sim.add_testbench(process)
+
+
+class TestDecoder(TestCaseWithSimulator):
+    def test_basic(self):
+        dec = Decoder(4)
+
+        async def process(sim: TestbenchContext):
+            assert sim.get(dec.o) == 0b0001
+
+            sim.set(dec.i, 1)
+            assert sim.get(dec.o) == 0b0010
+
+            sim.set(dec.i, 3)
+            assert sim.get(dec.o) == 0b1000
+
+            sim.set(dec.n, 1)
+            assert sim.get(dec.o) == 0b0000
+
+        with self.run_simulation(dec) as sim:
+            sim.add_testbench(process)

--- a/transactron/utils/amaranth_ext/coding.py
+++ b/transactron/utils/amaranth_ext/coding.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2019-2024 Amaranth HDL contributors
 
 from amaranth import *
-from transactron.utils.amaranth_ext.functions import count_leading_zeros
+from transactron.utils.amaranth_ext.functions import count_trailing_zeros
 
 
 __all__ = [
@@ -85,7 +85,7 @@ class PriorityEncoder(Elaboratable):
 
     def elaborate(self, platform):
         m = Module()
-        m.d.comb += self.o.eq(count_leading_zeros(self.i))
+        m.d.comb += self.o.eq(count_trailing_zeros(self.i))
         m.d.comb += self.n.eq(self.i == 0)
         return m
 


### PR DESCRIPTION
Fixes a problem introduced by #29, and adds tests which were originally in Amaranth.