### PR TITLE
Improved SimpleTestCircuit

### DIFF
--- a/transactron/core/method.py
+++ b/transactron/core/method.py
@@ -1,9 +1,10 @@
 from collections.abc import Sequence
+import enum
 
 from transactron.utils import *
 from amaranth import *
 from amaranth import tracer
-from typing import TYPE_CHECKING, Optional, Iterator, Unpack
+from typing import TYPE_CHECKING, Annotated, Optional, Iterator, TypeAlias, TypeVar, Unpack
 from .transaction_base import *
 from contextlib import contextmanager
 from transactron.utils.assign import AssignArg
@@ -19,7 +20,17 @@ if TYPE_CHECKING:
     from .transaction import Transaction  # noqa: F401
 
 
-__all__ = ["Method", "Methods"]
+__all__ = ["MethodDir", "Provided", "Required", "Method", "Methods"]
+
+
+class MethodDir(enum.Enum):
+    PROVIDED = enum.auto()
+    REQUIRED = enum.auto()
+
+
+_T = TypeVar("_T")
+Provided: TypeAlias = Annotated[_T, MethodDir.PROVIDED]
+Required: TypeAlias = Annotated[_T, MethodDir.REQUIRED]
 
 
 class Method(TransactionBase["Transaction | Method"]):

--- a/transactron/lib/adapters.py
+++ b/transactron/lib/adapters.py
@@ -125,6 +125,10 @@ class Adapter(AdapterBase):
         method = Method(name=name, i=i, o=o, src_loc=get_src_loc(src_loc))
         return Adapter(method, **kwargs)
 
+    def update_args(self, **kwargs: Unpack[AdapterBodyParams]):
+        self.kwargs.update(kwargs)
+        return self
+
     def set(self, with_validate_arguments: Optional[bool]):
         if with_validate_arguments is not None:
             self.with_validate_arguments = with_validate_arguments

--- a/transactron/testing/method_mock.py
+++ b/transactron/testing/method_mock.py
@@ -1,8 +1,9 @@
 from contextlib import contextmanager
 import functools
-from typing import Callable, Any, Optional
+from typing import Callable, Any, Optional, Unpack
 
 from amaranth.sim._async import SimulatorContext
+from transactron.core.body import AdapterBodyParams
 from transactron.lib.adapters import Adapter, AdapterBase
 from transactron.utils.transactron_helpers import async_mock_def_helper
 from .testbenchio import TestbenchIO
@@ -21,7 +22,13 @@ class MethodMock:
         validate_arguments: Optional[Callable[..., bool]] = None,
         enable: Callable[[], bool] = lambda: True,
         delay: float = 0,
+        **kwargs: Unpack[AdapterBodyParams],
     ):
+        if isinstance(adapter, Adapter):
+            adapter.set(with_validate_arguments=validate_arguments is not None).update_args(**kwargs)
+        else:
+            assert validate_arguments is None
+            assert kwargs == {}
         self.adapter = adapter
         self.function = function
         self.validate_arguments = validate_arguments


### PR DESCRIPTION
This PR changes `SimpleTestCircuit` so that `Adapter`s and `TestbenchIO`s can be automatically constructed for required methods. Type annotations is used to distinguish required methods from provided ones. Based on #30.