### PR TITLE
Move StableSelectingNetwork out of lib

### DIFF
--- a/test/utils/amaranth_ext/test_elaboratables.py
+++ b/test/utils/amaranth_ext/test_elaboratables.py
@@ -1,7 +1,7 @@
 import pytest
 import random
 
-from transactron.lib import StableSelectingNetwork
+from transactron.utils import StableSelectingNetwork
 from transactron.testing import TestCaseWithSimulator, TestbenchContext
 
 
@@ -9,7 +9,7 @@ class TestStableSelectingNetwork(TestCaseWithSimulator):
 
     @pytest.mark.parametrize("n", [2, 3, 7, 8])
     def test(self, n: int):
-        m = StableSelectingNetwork(n, [("data", 8)])
+        m = StableSelectingNetwork(n, 8)
 
         random.seed(42)
 
@@ -22,13 +22,13 @@ class TestStableSelectingNetwork(TestCaseWithSimulator):
                 expected_output_prefix = []
                 for i in range(n):
                     sim.set(m.valids[i], valids[i])
-                    sim.set(m.inputs[i].data, inputs[i])
+                    sim.set(m.inputs[i], inputs[i])
 
                     if valids[i]:
                         expected_output_prefix.append(inputs[i])
 
                 for i in range(total):
-                    out = sim.get(m.outputs[i].data)
+                    out = sim.get(m.outputs[i])
                     assert out == expected_output_prefix[i]
 
                 assert sim.get(m.output_cnt) == total

--- a/transactron/lib/connectors.py
+++ b/transactron/lib/connectors.py
@@ -12,7 +12,6 @@ __all__ = [
     "Connect",
     "ConnectTrans",
     "ManyToOneConnectTrans",
-    "StableSelectingNetwork",
     "Pipe",
 ]
 
@@ -341,84 +340,5 @@ class ManyToOneConnectTrans(Elaboratable):
             m.submodules[f"ManyToOneConnectTrans_input_{i}"] = ConnectTrans(
                 self.m_put_result, self.get_results[i], src_loc=self.src_loc
             )
-
-        return m
-
-
-class StableSelectingNetwork(Elaboratable):
-    """A network that groups inputs with a valid bit set.
-
-    The circuit takes `n` inputs with a valid signal each and
-    on the output returns a grouped and consecutive sequence of the provided
-    input signals. The order of valid inputs is preserved.
-
-    For example for input (0 is an invalid input):
-    0, a, 0, d, 0, 0, e
-
-    The circuit will return:
-    a, d, e, 0, 0, 0, 0
-
-    The circuit uses a divide and conquer algorithm.
-    The recursive call takes two bit vectors and each of them
-    is already properly sorted, for example:
-    v1 = [a, b, 0, 0]; v2 = [c, d, e, 0]
-
-    Now by shifting left v2 and merging it with v1, we get the result:
-    v = [a, b, c, d, e, 0, 0, 0]
-
-    Thus, the network has depth log_2(n).
-
-    """
-
-    def __init__(self, n: int, layout: MethodLayout):
-        self.n = n
-        self.layout = from_method_layout(layout)
-
-        self.inputs = [Signal(self.layout) for _ in range(n)]
-        self.valids = [Signal() for _ in range(n)]
-
-        self.outputs = [Signal(self.layout) for _ in range(n)]
-        self.output_cnt = Signal(range(n + 1))
-
-    def elaborate(self, platform):
-        m = TModule()
-
-        current_level = []
-        for i in range(self.n):
-            current_level.append((Array([self.inputs[i]]), self.valids[i]))
-
-        # Create the network using the bottom-up approach.
-        while len(current_level) >= 2:
-            next_level = []
-            while len(current_level) >= 2:
-                a, cnt_a = current_level.pop(0)
-                b, cnt_b = current_level.pop(0)
-
-                total_cnt = Signal(max(len(cnt_a), len(cnt_b)) + 1)
-                m.d.comb += total_cnt.eq(cnt_a + cnt_b)
-
-                total_len = len(a) + len(b)
-                merged = Array(Signal(self.layout) for _ in range(total_len))
-
-                for i in range(len(a)):
-                    m.d.comb += merged[i].eq(Mux(cnt_a <= i, b[i - cnt_a], a[i]))
-                for i in range(len(b)):
-                    m.d.comb += merged[len(a) + i].eq(Mux(len(a) + i - cnt_a >= len(b), 0, b[len(a) + i - cnt_a]))
-
-                next_level.append((merged, total_cnt))
-
-            # If we had an odd number of elements on the current level,
-            # move the item left to the next level.
-            if len(current_level) == 1:
-                next_level.append(current_level.pop(0))
-
-            current_level = next_level
-
-        last_level, total_cnt = current_level.pop(0)
-
-        for i in range(self.n):
-            m.d.comb += self.outputs[i].eq(last_level[i])
-
-        m.d.comb += self.output_cnt.eq(total_cnt)
 
         return m

--- a/transactron/utils/amaranth_ext/elaboratables.py
+++ b/transactron/utils/amaranth_ext/elaboratables.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager
 from typing import Literal, Optional, overload
 from collections.abc import Iterable
 from amaranth import *
+from amaranth_types import ShapeLike
 from transactron.utils._typing import HasElaborate, ModuleLike, ValueLike
 
 __all__ = [
@@ -13,6 +14,7 @@ __all__ = [
     "RoundRobin",
     "MultiPriorityEncoder",
     "RingMultiPriorityEncoder",
+    "StableSelectingNetwork",
 ]
 
 
@@ -529,4 +531,83 @@ class RingMultiPriorityEncoder(Elaboratable):
 
             m.d.comb += self.outputs[k].eq(corrected_out)
             m.d.comb += self.valids[k].eq(multi_enc.valids[k])
+        return m
+
+
+class StableSelectingNetwork(Elaboratable):
+    """A network that groups inputs with a valid bit set.
+
+    The circuit takes `n` inputs with a valid signal each and
+    on the output returns a grouped and consecutive sequence of the provided
+    input signals. The order of valid inputs is preserved.
+
+    For example for input (0 is an invalid input):
+    0, a, 0, d, 0, 0, e
+
+    The circuit will return:
+    a, d, e, 0, 0, 0, 0
+
+    The circuit uses a divide and conquer algorithm.
+    The recursive call takes two bit vectors and each of them
+    is already properly sorted, for example:
+    v1 = [a, b, 0, 0]; v2 = [c, d, e, 0]
+
+    Now by shifting left v2 and merging it with v1, we get the result:
+    v = [a, b, c, d, e, 0, 0, 0]
+
+    Thus, the network has depth log_2(n).
+
+    """
+
+    def __init__(self, n: int, shape: ShapeLike):
+        self.n = n
+        self.shape = shape
+
+        self.inputs = [Signal(shape) for _ in range(n)]
+        self.valids = [Signal() for _ in range(n)]
+
+        self.outputs = [Signal(shape) for _ in range(n)]
+        self.output_cnt = Signal(range(n + 1))
+
+    def elaborate(self, platform):
+        m = Module()
+
+        current_level = []
+        for i in range(self.n):
+            current_level.append((Array([self.inputs[i]]), self.valids[i]))
+
+        # Create the network using the bottom-up approach.
+        while len(current_level) >= 2:
+            next_level = []
+            while len(current_level) >= 2:
+                a, cnt_a = current_level.pop(0)
+                b, cnt_b = current_level.pop(0)
+
+                total_cnt = Signal(max(len(cnt_a), len(cnt_b)) + 1)
+                m.d.comb += total_cnt.eq(cnt_a + cnt_b)
+
+                total_len = len(a) + len(b)
+                merged = Array(Signal(self.shape) for _ in range(total_len))
+
+                for i in range(len(a)):
+                    m.d.comb += merged[i].eq(Mux(cnt_a <= i, b[i - cnt_a], a[i]))
+                for i in range(len(b)):
+                    m.d.comb += merged[len(a) + i].eq(Mux(len(a) + i - cnt_a >= len(b), 0, b[len(a) + i - cnt_a]))
+
+                next_level.append((merged, total_cnt))
+
+            # If we had an odd number of elements on the current level,
+            # move the item left to the next level.
+            if len(current_level) == 1:
+                next_level.append(current_level.pop(0))
+
+            current_level = next_level
+
+        last_level, total_cnt = current_level.pop(0)
+
+        for i in range(self.n):
+            m.d.comb += self.outputs[i].eq(last_level[i])
+
+        m.d.comb += self.output_cnt.eq(total_cnt)
+
         return m


### PR DESCRIPTION
This PR moves `StableSelectingNetwork` out of `lib`, as it's just an `Elaboratable` without any dependencies on the Transactron core. Also, the interface is changed to avoid using lists of signals, which are less ergonomic compared to `ArrayLayout`. Similar interface change is made in `MultiPriorityEncoder`.