### PR TITLE
`ComponentInterface` typing wrapper for lib.wiring interfaces

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "transactron"
 dynamic = ["version"]
 dependencies = [
     "amaranth == 0.5.3",
-    "amaranth-stubs @ git+https://github.com/piotro888/amaranth-stubs.git@e25a7fa11d4a0d66ed18190f31b60914f222e74c",
+    "amaranth-stubs @ git+https://github.com/kuznia-rdzeni/amaranth-stubs.git@8841b43f0a1e8aa0453dc0c8df1dc38818a8fcac",
     "dataclasses-json == 0.6.3",
     "tabulate == 0.9.0"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "transactron"
 dynamic = ["version"]
 dependencies = [
     "amaranth == 0.5.3",
-    "amaranth-stubs @ git+https://github.com/kuznia-rdzeni/amaranth-stubs.git@d62b68241fa1881244470e63931ceb635ac91044",
+    "amaranth-stubs @ git+https://github.com/piotro888/amaranth-stubs.git@e25a7fa11d4a0d66ed18190f31b60914f222e74c",
     "dataclasses-json == 0.6.3",
     "tabulate == 0.9.0"
 ]

--- a/test/utils/test_component_interface.py
+++ b/test/utils/test_component_interface.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
-from amaranth import Signal
+from amaranth import Signal, unsigned
+from amaranth.lib.data import ArrayLayout, View
 from amaranth.lib.wiring import Component, Flow, In
 from transactron.utils.amaranth_ext.component_interface import CIn, COut, ComponentInterface, ComponentSignal
 
@@ -23,6 +24,7 @@ class TBInterface(ComponentInterface):
         self.s = SubInterface()
         self.f = SubInterface().flipped()
         self.uf = SubInterface().flipped().flipped()
+        self.a = COut(ArrayLayout(2, 3))
 
 
 class TestComponentInterface(TestCase):
@@ -53,3 +55,8 @@ class TestComponentInterface(TestCase):
         assert isinstance(ci.i, ComponentSignal)
         assert isinstance(ci.f.i, ComponentSignal)
         assert isinstance(ci.uf.f.i, ComponentSignal)
+
+        assert t.iface.f.f.i.shape() == unsigned(1)
+        assert t.iface.i.shape() == unsigned(2)
+        assert t.iface.a.shape() == ArrayLayout(2, 3)
+        assert isinstance(t.iface.a, View)

--- a/test/utils/test_component_interface.py
+++ b/test/utils/test_component_interface.py
@@ -4,16 +4,19 @@ from amaranth import Signal
 from amaranth.lib.wiring import Component, Flow, In
 from transactron.utils.amaranth_ext.component_interface import CIn, COut, ComponentInterface, ComponentSignal
 
+
 class SubSubInterface(ComponentInterface):
     def __init__(self):
         self.i = CIn()
+
 
 class SubInterface(ComponentInterface):
     def __init__(self):
         self.i = CIn()
         self.f = SubSubInterface().flipped()
 
-class TestInterface(ComponentInterface):
+
+class TBInterface(ComponentInterface):
     def __init__(self):
         self.i = CIn(2)
         self.o = COut(2)
@@ -21,33 +24,31 @@ class TestInterface(ComponentInterface):
         self.f = SubInterface().flipped()
         self.uf = SubInterface().flipped().flipped()
 
+
 class TestComponentInterface(TestCase):
     def test_a(self):
         class TestComponent(Component):
-            iface: TestInterface
+            iface: TBInterface
 
             def __init__(self):
-                super().__init__({"iface": In(TestInterface().signature)})
-        
+                super().__init__({"iface": In(TBInterface().signature)})
+
         t = TestComponent()
 
         assert isinstance(t.iface.i, Signal)
         assert isinstance(t.iface.s.i, Signal)
         assert isinstance(t.iface.f.i, Signal)
-        
-        ci = TestInterface()
+
+        ci = TBInterface()
         sig = ci.signature
 
         assert sig.members["s"].signature.members["i"].flow is Flow.In
         assert sig.members["f"].signature.members["i"].flow is Flow.Out
         assert sig.members["uf"].signature.members["i"].flow is Flow.In
-        
-        assert ci.s.i._flow is Flow.In
-        #assert ci.f.i._flow is Flow.Out
-        
-        #assert sig.s.i.f.i.flow is Flow.Out
-        #assert sig.s.f.f.i.flow is Flow.In
-        #assert sig.s.uf.f.i.flow is Flow.Out
+
+        assert sig.members["s"].signature.members["f"].signature.members["i"].flow is Flow.Out
+        assert sig.members["f"].signature.members["f"].signature.members["i"].flow is Flow.In
+        assert sig.members["uf"].signature.members["f"].signature.members["i"].flow is Flow.Out
 
         assert isinstance(ci.i, ComponentSignal)
         assert isinstance(ci.f.i, ComponentSignal)

--- a/test/utils/test_component_interface.py
+++ b/test/utils/test_component_interface.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 from amaranth import Signal, unsigned
 from amaranth.lib.data import ArrayLayout, View
 from amaranth.lib.wiring import Component, Flow, In
-from transactron.utils.amaranth_ext.component_interface import CIn, COut, ComponentInterface, ComponentSignal
+from transactron.utils.amaranth_ext.component_interface import CIn, COut, ComponentInterface
 
 
 class SubSubInterface(ComponentInterface):
@@ -51,10 +51,6 @@ class TestComponentInterface(TestCase):
         assert sig.members["s"].signature.members["f"].signature.members["i"].flow is Flow.Out
         assert sig.members["f"].signature.members["f"].signature.members["i"].flow is Flow.In
         assert sig.members["uf"].signature.members["f"].signature.members["i"].flow is Flow.Out
-
-        assert isinstance(ci.i, ComponentSignal)
-        assert isinstance(ci.f.i, ComponentSignal)
-        assert isinstance(ci.uf.f.i, ComponentSignal)
 
         assert t.iface.f.f.i.shape() == unsigned(1)
         assert t.iface.i.shape() == unsigned(2)

--- a/test/utils/test_component_interface.py
+++ b/test/utils/test_component_interface.py
@@ -1,0 +1,54 @@
+from unittest import TestCase
+
+from amaranth import Signal
+from amaranth.lib.wiring import Component, Flow, In
+from transactron.utils.amaranth_ext.component_interface import CIn, COut, ComponentInterface, ComponentSignal
+
+class SubSubInterface(ComponentInterface):
+    def __init__(self):
+        self.i = CIn()
+
+class SubInterface(ComponentInterface):
+    def __init__(self):
+        self.i = CIn()
+        self.f = SubSubInterface().flipped()
+
+class TestInterface(ComponentInterface):
+    def __init__(self):
+        self.i = CIn(2)
+        self.o = COut(2)
+        self.s = SubInterface()
+        self.f = SubInterface().flipped()
+        self.uf = SubInterface().flipped().flipped()
+
+class TestComponentInterface(TestCase):
+    def test_a(self):
+        class TestComponent(Component):
+            iface: TestInterface
+
+            def __init__(self):
+                super().__init__({"iface": In(TestInterface().signature)})
+        
+        t = TestComponent()
+
+        assert isinstance(t.iface.i, Signal)
+        assert isinstance(t.iface.s.i, Signal)
+        assert isinstance(t.iface.f.i, Signal)
+        
+        ci = TestInterface()
+        sig = ci.signature
+
+        assert sig.members["s"].signature.members["i"].flow is Flow.In
+        assert sig.members["f"].signature.members["i"].flow is Flow.Out
+        assert sig.members["uf"].signature.members["i"].flow is Flow.In
+        
+        assert ci.s.i._flow is Flow.In
+        #assert ci.f.i._flow is Flow.Out
+        
+        #assert sig.s.i.f.i.flow is Flow.Out
+        #assert sig.s.f.f.i.flow is Flow.In
+        #assert sig.s.uf.f.i.flow is Flow.Out
+
+        assert isinstance(ci.i, ComponentSignal)
+        assert isinstance(ci.f.i, ComponentSignal)
+        assert isinstance(ci.uf.f.i, ComponentSignal)

--- a/transactron/utils/amaranth_ext/component_interface.py
+++ b/transactron/utils/amaranth_ext/component_interface.py
@@ -96,6 +96,7 @@ class ComponentInterface(AbstractComponentInterface):
     --------
     .. highlight:: python
     .. code-block:: python
+
         class ExampleInterface(ComponentInterface):
             def __init__(self, data_width: int):
                 self.data_in = CIn(data_width)

--- a/transactron/utils/amaranth_ext/component_interface.py
+++ b/transactron/utils/amaranth_ext/component_interface.py
@@ -24,7 +24,7 @@ class ComponentSignal(Value):
     """
 
     _flow: Flow  # Don't access directly - flips are not applied here.
-    _shape: Shape
+    _shape: ShapeLike
 
     def __init__(self, flow: Flow, shape: Optional[ShapeLike] = None):
         """
@@ -35,15 +35,16 @@ class ComponentSignal(Value):
         shape: Optional ShapeLike
             Shape of `Signal` member. `unsigned(1)` by default.
         """
-        self._shape = unsigned(1) if shape is None else Shape.cast(shape)
+        self._shape = unsigned(1) if shape is None else shape
         self._flow = flow
 
     def as_member(self):
+        # from original (not casted) shape
         return self._flow(self._shape)
 
     # Value abstract methods
     def shape(self):
-        return self._shape
+        return Shape.cast(self._shape)
 
     def _rhs_signals(self):
         # Should never be called - only used from HDL

--- a/transactron/utils/amaranth_ext/component_interface.py
+++ b/transactron/utils/amaranth_ext/component_interface.py
@@ -1,20 +1,43 @@
-from amaranth import Shape, ShapeLike, Signal, ValueLike, unsigned, Value
-from amaranth.lib.wiring import FlippedSignature, Signature, Flow, Member
+from amaranth import Shape, ShapeLike, unsigned, Value
+from amaranth.lib.wiring import Signature, Flow, Member
 from amaranth_types import AbstractInterface, AbstractSignature
 
-from copy import copy
-from typing import Optional, Self
+from typing import Any, Mapping, Optional
+
+__all__ = [
+    "ComponentSignal",
+    "CIn",
+    "COut",
+    "ComponentInterface",
+    "FlippedComponentInterface",
+]
+
 
 class ComponentSignal(Value):
-    _flow: Flow # flow donsn't repect flips!!!
+    """Component Signal
+    Element of `ComponentInterface`. Use `CIn` and `COut` wrappers.
+
+    It is compatible with `Signal` for type checking and stores information for `Signature` construction.
+    It should never be referenced in HDL and exist only on type level.
+    Real `Signal` is created in place of `ComponentSignal` in `Component` constructor.
+    """
+
+    _flow: Flow  # Don't access directly - flips are not applied here.
     _shape: Shape
-    
+
     def __init__(self, flow: Flow, shape: Optional[ShapeLike] = None):
+        """
+        Parameters
+        ----------
+        flow: Flow
+            Direction of `Signal` member. `Flow.In` or `Flow.Out`.
+        shape: Optional ShapeLike
+            Shape of `Signal` member. `unsigned(1)` by default.
+        """
         self._shape = unsigned(1) if shape is None else Shape.cast(shape)
         self._flow = flow
-    
-    @property
-    def member(self):
+
+    def as_member(self):
         return self._flow(self._shape)
 
     # Value abstract methods
@@ -22,57 +45,70 @@ class ComponentSignal(Value):
         return self._shape
 
     def _rhs_signals(self):
-        # This method should never be called
-        # IOSignal is going to be substituted by a Component constructor or be used only as a type
+        # Should never be called - only used from HDL
         raise NotImplementedError
 
+    # Signal API compatiblitly types (Signal is @final, Value is used instead)
+    name: str
+    decoder: Any
+
+
 class CIn(ComponentSignal):
+    """`ComponentSignal` with `Flow.In` direction."""
+
     def __init__(self, shape: Optional[ShapeLike] = None):
         super().__init__(Flow.In, shape)
+
+
 class COut(ComponentSignal):
+    """`ComponentSignal` with `Flow.Out` direction."""
+
     def __init__(self, shape: Optional[ShapeLike] = None):
         super().__init__(Flow.Out, shape)
 
-# is AbstractSignature needed?
-# oh, we return signature -> this doesn't need to be compatiblie
-# but we can make members.
-# or even flippedsignature
-# make flippedcomponentinterface?
-
-class FlippedComponentInterface(AbstractInterface[AbstractSignature]):
-    def __init__(self, _base: "ComponentInterface"):
-        self._base = _base
-
-    def __getattribute__(self, name: str, /):
-        return self.base.__getattribute__(name)
-
-    def signature(self):
-        return Signature(Signature(self._base._to_members_list()).flip().members)
 
 class ComponentInterface(AbstractInterface[AbstractSignature]):
-    _is_flipped: bool
-    
+    """Component Interface
+    Syntactic sugar for using typed lib.wiring `Signature`s in `Component`.
+
+    It allows to avoid defining desired Amaranth `Signature` and separetly `AbstractInterface` of `Signals` to get
+    `Component` attribute-level typing of interface.
+
+    Interface should be constructed in `__init__` of class that inherits `ComponentInterface`, by defining
+    instance attributes.
+    Only allowed attributes in `ComponentInterface` are of `ComponentSignal` (see `CIn` and `COut`)
+    and `ComponentInterface` (nested interface) types.
+
+    Resulting class can be used directly as typing hint for class-level interface attribute, that will be later
+    constructed  by `Component`. Use `signature` property to get amaranth `Signature` in `Component` constructor.
+
+    Examples
+    --------
+    .. highlight:: python
+    .. code-block:: python
+        class ExampleInterface(ComponentInterface):
+            def __init__(self, data_width: int):
+                self.data_in = CIn(data_width)
+                self.data_out = COut(data_width)
+                self.valid = CIn()
+                self.x = SubInterface().flipped()
+
+        class Example(Component):
+            bus: ExampleInterface
+            def __init__(self):
+                super().__init__({bus: In(ExampleInterface(2).signature)})
+    """
+
     @property
-    def signature(self) -> Signature:
-        signature = Signature(self._to_members_list())
+    def signature(self) -> AbstractSignature:
+        """Amaranth lib.wiring `Signature` constructed from defined `ComponentInterface` attributes."""
+        return Signature(self._to_members_list())
 
-        if self._get_flipped():
-            # somehow better? or use in to membres list??
-            return Signature(signature.flip().members)
-        else:
-            return signature 
-
-    #def flipped(self) -> Self:
-    #    # make new from members list?
-    #    flipped = copy(self)
-    #    flipped._is_flipped = not self._get_flipped()
-    #    return flipped
-
-    def flipped(self) -> FlippedComponentInterface:
+    def flipped(self) -> "FlippedComponentInterface":
+        """`ComponentInterface` with flipped `Flow` direction of members."""
         return FlippedComponentInterface(self)
-    
-    # or return SignatureMembers???
-    def _to_members_list(self, *, name_prefix: str = "") -> dict[str, Member]:
+
+    def _to_members_list(self, *, name_prefix: str = "") -> Mapping[str, Member]:
         res = {}
         for m_name in dir(self):
             if m_name.startswith("_") or m_name == "signature" or m_name == "flipped":
@@ -80,21 +116,33 @@ class ComponentInterface(AbstractInterface[AbstractSignature]):
 
             m_val = getattr(self, m_name)
             if isinstance(m_val, ComponentSignal):
-                res[m_name] = m_val.member
-            elif isinstance(m_val, ComponentInterface):                
-                m_val_flow = Flow.In if m_val._get_flipped() else Flow.Out
-                res[m_name] = m_val_flow(Signature(m_val._to_members_list(name_prefix=name_prefix+m_name+".")))
+                res[m_name] = m_val.as_member()
+            elif isinstance(m_val, ComponentInterface):
+                res[m_name] = Flow.Out(m_val.signature)
             else:
                 raise AttributeError(
-                        f"Illegal attribute `{name_prefix+m_name}`. "
-                        "Expected CIn, COut or ComponentInterface")
-            
+                    f"Illegal attribute `{name_prefix+m_name}`. Expected `CIn`, `COut` or `ComponentInterface`"
+                )
         return res
-                
-    def _get_flipped(self) -> bool:
-        try:
-            return self._is_flipped
-        except AttributeError:
-            self._is_flipped = False
-            return self._is_flipped
 
+
+class FlippedComponentInterface(ComponentInterface):
+    """
+    Represents another `ComponentInterface` with flipped `Flow` directions of its members.
+    Flip is applied only in resulting `signature` property.
+    """
+
+    def __init__(self, base: ComponentInterface):
+        self._base = base
+
+    def __getattr__(self, name: str):
+        return getattr(self._base, name)
+
+    @property
+    def signature(self) -> AbstractSignature:
+        """Amaranth lib.wiring `Signature` constructed from defined `ComponentInterface` attributes."""
+        return self._base.signature.flip()
+
+    def flipped(self) -> "FlippedComponentInterface":
+        """`ComponentInterface` with flipped `Flow` direction of members."""
+        return FlippedComponentInterface(self)

--- a/transactron/utils/amaranth_ext/component_interface.py
+++ b/transactron/utils/amaranth_ext/component_interface.py
@@ -111,7 +111,7 @@ class ComponentInterface(AbstractComponentInterface):
     """
 
     @property
-    def signature(self) -> Signature:
+    def signature(self) -> AbstractSignature:
         """Amaranth lib.wiring `Signature` constructed from defined `ComponentInterface` attributes."""
         return Signature(self._to_members_list())
 

--- a/transactron/utils/amaranth_ext/component_interface.py
+++ b/transactron/utils/amaranth_ext/component_interface.py
@@ -49,7 +49,12 @@ class ComponentSignal(Value):
         raise NotImplementedError
 
     # Signal API compatiblitly types (Signal is @final, Value is used instead)
+    width: int
+    signed: bool
     name: str
+    init: int
+    reset_less: bool
+    attrs: dict
     decoder: Any
 
 

--- a/transactron/utils/amaranth_ext/component_interface.py
+++ b/transactron/utils/amaranth_ext/component_interface.py
@@ -76,6 +76,10 @@ class COut(ComponentSignal):
 class AbstractComponentInterface(AbstractInterface[AbstractSignature]):
     def flipped(self) -> "AbstractComponentInterface": ...
 
+    # Remove after pyright update
+    @property
+    def signature(self) -> AbstractSignature: ...
+
 
 class ComponentInterface(AbstractComponentInterface):
     """Component Interface

--- a/transactron/utils/amaranth_ext/component_interface.py
+++ b/transactron/utils/amaranth_ext/component_interface.py
@@ -1,0 +1,100 @@
+from amaranth import Shape, ShapeLike, Signal, ValueLike, unsigned, Value
+from amaranth.lib.wiring import FlippedSignature, Signature, Flow, Member
+from amaranth_types import AbstractInterface, AbstractSignature
+
+from copy import copy
+from typing import Optional, Self
+
+class ComponentSignal(Value):
+    _flow: Flow # flow donsn't repect flips!!!
+    _shape: Shape
+    
+    def __init__(self, flow: Flow, shape: Optional[ShapeLike] = None):
+        self._shape = unsigned(1) if shape is None else Shape.cast(shape)
+        self._flow = flow
+    
+    @property
+    def member(self):
+        return self._flow(self._shape)
+
+    # Value abstract methods
+    def shape(self):
+        return self._shape
+
+    def _rhs_signals(self):
+        # This method should never be called
+        # IOSignal is going to be substituted by a Component constructor or be used only as a type
+        raise NotImplementedError
+
+class CIn(ComponentSignal):
+    def __init__(self, shape: Optional[ShapeLike] = None):
+        super().__init__(Flow.In, shape)
+class COut(ComponentSignal):
+    def __init__(self, shape: Optional[ShapeLike] = None):
+        super().__init__(Flow.Out, shape)
+
+# is AbstractSignature needed?
+# oh, we return signature -> this doesn't need to be compatiblie
+# but we can make members.
+# or even flippedsignature
+# make flippedcomponentinterface?
+
+class FlippedComponentInterface(AbstractInterface[AbstractSignature]):
+    def __init__(self, _base: "ComponentInterface"):
+        self._base = _base
+
+    def __getattribute__(self, name: str, /):
+        return self.base.__getattribute__(name)
+
+    def signature(self):
+        return Signature(Signature(self._base._to_members_list()).flip().members)
+
+class ComponentInterface(AbstractInterface[AbstractSignature]):
+    _is_flipped: bool
+    
+    @property
+    def signature(self) -> Signature:
+        signature = Signature(self._to_members_list())
+
+        if self._get_flipped():
+            # somehow better? or use in to membres list??
+            return Signature(signature.flip().members)
+        else:
+            return signature 
+
+    #def flipped(self) -> Self:
+    #    # make new from members list?
+    #    flipped = copy(self)
+    #    flipped._is_flipped = not self._get_flipped()
+    #    return flipped
+
+    def flipped(self) -> FlippedComponentInterface:
+        return FlippedComponentInterface(self)
+    
+    # or return SignatureMembers???
+    def _to_members_list(self, *, name_prefix: str = "") -> dict[str, Member]:
+        res = {}
+        for m_name in dir(self):
+            if m_name.startswith("_") or m_name == "signature" or m_name == "flipped":
+                continue
+
+            m_val = getattr(self, m_name)
+            if isinstance(m_val, ComponentSignal):
+                res[m_name] = m_val.member
+            elif isinstance(m_val, ComponentInterface):                
+                m_val_flow = Flow.In if m_val._get_flipped() else Flow.Out
+                res[m_name] = m_val_flow(Signature(m_val._to_members_list(name_prefix=name_prefix+m_name+".")))
+            else:
+                raise AttributeError(
+                        f"Illegal attribute `{name_prefix+m_name}`. "
+                        "Expected CIn, COut or ComponentInterface")
+            
+        return res
+                
+    def _get_flipped(self) -> bool:
+        try:
+            return self._is_flipped
+        except AttributeError:
+            self._is_flipped = False
+            return self._is_flipped
+

--- a/transactron/utils/amaranth_ext/component_interface.py
+++ b/transactron/utils/amaranth_ext/component_interface.py
@@ -2,12 +2,13 @@ from amaranth import Shape, ShapeLike, unsigned, Value
 from amaranth.lib.wiring import Signature, Flow, Member
 from amaranth_types import AbstractInterface, AbstractSignature
 
-from typing import Any, Generic, Mapping, Optional, Self, TypeVar
+from typing import Any, Generic, Mapping, Optional, Self, TypeVar, final
 
 __all__ = [
     "ComponentSignal",
     "CIn",
     "COut",
+    "AbstractComponentInterface",
     "ComponentInterface",
     "FlippedComponentInterface",
 ]
@@ -72,7 +73,11 @@ class COut(ComponentSignal):
         super().__init__(Flow.Out, shape)
 
 
-class ComponentInterface(AbstractInterface[AbstractSignature]):
+class AbstractComponentInterface(AbstractInterface[AbstractSignature]):
+    def flipped(self) -> "AbstractComponentInterface": ...
+
+
+class ComponentInterface(AbstractComponentInterface):
     """Component Interface
     Syntactic sugar for using typed lib.wiring `Signature`s in `Component`.
 
@@ -105,7 +110,7 @@ class ComponentInterface(AbstractInterface[AbstractSignature]):
     """
 
     @property
-    def signature(self) -> AbstractSignature:
+    def signature(self) -> Signature:
         """Amaranth lib.wiring `Signature` constructed from defined `ComponentInterface` attributes."""
         return Signature(self._to_members_list())
 
@@ -132,10 +137,11 @@ class ComponentInterface(AbstractInterface[AbstractSignature]):
         return res
 
 
-_T_ComponentInterface = TypeVar("_T_ComponentInterface", bound="ComponentInterface")
+_T_ComponentInterface = TypeVar("_T_ComponentInterface", bound=ComponentInterface)
 
 
-class FlippedComponentInterface(AbstractInterface[AbstractSignature], Generic[_T_ComponentInterface]):
+@final
+class FlippedComponentInterface(AbstractComponentInterface, Generic[_T_ComponentInterface]):
     """
     Represents `ComponentInterface` with flipped `Flow` directions of its members.
     Flip is applied only in resulting `signature` property.


### PR DESCRIPTION
Redesign of concept from Coreblocks PR https://github.com/kuznia-rdzeni/coreblocks/pull/726.
Class that can be used both for typing and to get amaranth Signature for use in Component constructor.
