### PR TITLE
Look for Required/Provided annotations in base classes too

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "transactron"
 dynamic = ["version"]
 dependencies = [
     "amaranth == 0.5.3",
-    "amaranth-stubs @ git+https://github.com/kuznia-rdzeni/amaranth-stubs.git@8841b43f0a1e8aa0453dc0c8df1dc38818a8fcac",
+    "amaranth-stubs @ git+https://github.com/kuznia-rdzeni/amaranth-stubs.git@481b28c70812936d067e93e4e4cf2eb34bcc50d3",
     "dataclasses-json == 0.6.3",
     "tabulate == 0.9.0"
 ]

--- a/test/testing/test_method_mock.py
+++ b/test/testing/test_method_mock.py
@@ -33,7 +33,18 @@ class DerivedMethodMockTestCircuit(SimpleMethodMockTestCircuit):
     pass
 
 
-@pytest.mark.parametrize("test_circuit", [SimpleMethodMockTestCircuit, DerivedMethodMockTestCircuit])
+class MroTestBase:
+    method: int
+    wrapper: int
+
+
+class MroMethodMockTestCircuit(SimpleMethodMockTestCircuit, MroTestBase):
+    pass
+
+
+@pytest.mark.parametrize(
+    "test_circuit", [SimpleMethodMockTestCircuit, DerivedMethodMockTestCircuit, MroMethodMockTestCircuit]
+)
 class TestMethodMock(TestCaseWithSimulator):
     async def process(self, sim: TestbenchContext):
         for _ in range(20):

--- a/test/testing/test_method_mock.py
+++ b/test/testing/test_method_mock.py
@@ -2,6 +2,7 @@ import random
 from amaranth import *
 from amaranth.sim import *
 from amaranth.lib.data import StructLayout
+import pytest
 
 from transactron import *
 from transactron.testing import TestCaseWithSimulator, TestbenchContext
@@ -28,6 +29,11 @@ class SimpleMethodMockTestCircuit(Elaboratable):
         return m
 
 
+class DerivedMethodMockTestCircuit(SimpleMethodMockTestCircuit):
+    pass
+
+
+@pytest.mark.parametrize("test_circuit", [SimpleMethodMockTestCircuit, DerivedMethodMockTestCircuit])
 class TestMethodMock(TestCaseWithSimulator):
     async def process(self, sim: TestbenchContext):
         for _ in range(20):
@@ -39,10 +45,10 @@ class TestMethodMock(TestCaseWithSimulator):
     def method_mock(self, input):
         return {"output": input + 1}
 
-    def test_method_mock_simple(self):
+    def test_method_mock_simple(self, test_circuit):
         random.seed(42)
         self.width = 4
-        self.dut = SimpleTestCircuit(SimpleMethodMockTestCircuit(self.width))
+        self.dut = SimpleTestCircuit(test_circuit(self.width))
 
         with self.run_simulation(self.dut) as sim:
             sim.add_testbench(self.process)

--- a/transactron/testing/infrastructure.py
+++ b/transactron/testing/infrastructure.py
@@ -4,6 +4,7 @@ import logging
 import os
 import random
 import functools
+import inspect
 from contextlib import contextmanager, nullcontext
 from collections.abc import Callable
 from typing import TypeVar, Generic, Type, TypeGuard, Any, cast, TypeAlias, Optional
@@ -92,7 +93,9 @@ class SimpleTestCircuit(Elaboratable, Generic[_T_HasElaborate]):
         m = Module()
 
         m.submodules.dut = self._dut
-        hints = self._dut.__class__.__annotations__
+        hints: dict[str, Any] = {}
+        for cls in self._dut.__class__.__mro__:
+            hints = {**hints, **inspect.get_annotations(cls, eval_str=True)}
 
         for name, attr in vars(self._dut).items():
             if guard_nested_collection(attr, Method | Methods) and attr:

--- a/transactron/testing/infrastructure.py
+++ b/transactron/testing/infrastructure.py
@@ -99,7 +99,11 @@ class SimpleTestCircuit(Elaboratable, Generic[_T_HasElaborate]):
 
         for name, attr in vars(self._dut).items():
             if guard_nested_collection(attr, Method | Methods) and attr:
-                if name in hints and MethodDir.REQUIRED in hints[name].__metadata__:
+                if (
+                    name in hints
+                    and hasattr(hints[name], "__metadata__")
+                    and MethodDir.REQUIRED in hints[name].__metadata__
+                ):
                     adapter_type = Adapter
                 else:  # PROVIDED is the default
                     adapter_type = AdapterTrans

--- a/transactron/testing/infrastructure.py
+++ b/transactron/testing/infrastructure.py
@@ -94,8 +94,8 @@ class SimpleTestCircuit(Elaboratable, Generic[_T_HasElaborate]):
 
         m.submodules.dut = self._dut
         hints: dict[str, Any] = {}
-        for cls in self._dut.__class__.__mro__:
-            hints = {**hints, **inspect.get_annotations(cls, eval_str=True)}
+        for cls in reversed(self._dut.__class__.__mro__):
+            hints.update(inspect.get_annotations(cls, eval_str=True))
 
         for name, attr in vars(self._dut).items():
             if guard_nested_collection(attr, Method | Methods) and attr:


### PR DESCRIPTION
To avoid repeating yourself, when subclassing is used, annotations from base classes are still used in `SimpleTestCircuit` to direct adapter creation.

Also, the use of `__annotations__` is replaced by `inspect.get_annotations`, which is described as a best practice in Python docs.