### PR TITLE
Orphaned simultaneous transactions fix

### DIFF
--- a/transactron/core/transaction_base.py
+++ b/transactron/core/transaction_base.py
@@ -102,6 +102,8 @@ class TransactionBase(Owned, Protocol, Generic[_T]):
             The `Transaction`\\s or `Method`\\s to be executed simultaneously.
         """
         self.simultaneous_list += others
+        for other in others:
+            other.simultaneous_list.append(self)  # type: ignore
 
     def simultaneous_alternatives(self, *others: _T) -> None:
         """Adds exclusive simultaneity relations.


### PR DESCRIPTION
It turns out that, due to how simultaneous transactions are implemented, a transaction nested in and simultaneous with a method is run if the method has no callers. This PR detects such situations and disables the transaction. Maybe a little hacky, but it's the simplest solution I came up with.

Fixes #45.