### PR TITLE
One-hot mux circuit

### DIFF
--- a/transactron/utils/amaranth_ext/memory.py
+++ b/transactron/utils/amaranth_ext/memory.py
@@ -6,6 +6,8 @@ from amaranth.hdl import AlreadyElaborated
 from typing import Optional, Any, final
 from collections.abc import Iterable
 
+from transactron.utils.amaranth_ext.elaboratables import OneHotMux
+
 from .. import get_src_loc
 from amaranth_types.types import ShapeLike, ValueLike
 
@@ -349,19 +351,18 @@ class MultiportILVTMemory(BaseMultiportMemory):
             m.d.sync += [read_en_bypass.eq(read_port.en), read_addr_bypass.eq(read_port.addr)]
 
             bank_data = Signal(self.shape)
-            bypass_data = Signal(self.shape)
-            bypass_en = Signal()
             with m.Switch(ilvt_read_ports[index].data):
                 for value in range(len(self.write_ports)):
                     with m.Case(value):
                         m.d.comb += [bank_data.eq(m.submodules[f"bank_{value}"].read_ports[index].data)]
 
-            for idx, write_port in enumerate(self.write_ports):
-                if write_port in read_port.transparent_for:
-                    with m.If((write_addr_bypass[idx] == read_addr_bypass) & write_en_bypass[idx]):
-                        m.d.comb += [bypass_en.eq(1), bypass_data.eq(write_data_bypass[idx])]
+            mux_inputs = [
+                ((write_addr_bypass[idx] == read_addr_bypass) & write_en_bypass[idx], write_data_bypass[idx])
+                for idx, write_port in enumerate(self.write_ports)
+                if write_port in read_port.transparent_for
+            ]
+            new_data = OneHotMux.create(m, mux_inputs, bank_data)
 
-            new_data = Mux(bypass_en, bypass_data, bank_data)
             m.d.comb += [read_port.data.eq(Mux(read_en_bypass, new_data, read_port.data))]
 
         return m


### PR DESCRIPTION
This PR adds a `OneHotMux` module, which is internally implemented using `OneHotSwitch`. This allows some cases where a one-hot mux is needed to be expressed cleaner.

Side note: it needs to be checked of `OneHotSwitch` actually reliably generates Yosys `$pmux` cells, as a lot has happened in Amaranth since this was last checked. I can't find any mention of reliable one-hot muxes in Amaranth codebase, so we should probably ask Amaranth devs about it.