### PR TITLE
Fix combinational loop in multiport memory impls

### DIFF
--- a/transactron/utils/amaranth_ext/memory.py
+++ b/transactron/utils/amaranth_ext/memory.py
@@ -276,7 +276,9 @@ class MultiportXORMemory(BaseMultiportMemory):
                 m.d.comb += [port.addr.eq(self.read_ports[idx].addr), port.en.eq(self.read_ports[idx].en)]
 
         for index, port in enumerate(self.read_ports):
-            m.d.comb += [port.data.eq(Mux(read_en_bypass[index], read_xors[index], port.data))]
+            sync_data = Signal.like(port.data)
+            m.d.sync += sync_data.eq(port.data)
+            m.d.comb += [port.data.eq(Mux(read_en_bypass[index], read_xors[index], sync_data))]
 
         return m
 
@@ -362,6 +364,8 @@ class MultiportILVTMemory(BaseMultiportMemory):
                         m.d.comb += [bypass_en.eq(1), bypass_data.eq(write_data_bypass[idx])]
 
             new_data = Mux(bypass_en, bypass_data, bank_data)
-            m.d.comb += [read_port.data.eq(Mux(read_en_bypass, new_data, read_port.data))]
+            sync_data = Signal.like(read_port.data)
+            m.d.sync += sync_data.eq(read_port.data)
+            m.d.comb += [read_port.data.eq(Mux(read_en_bypass, new_data, sync_data))]
 
         return m


### PR DESCRIPTION
This PR fixes a combinational loop present in recently merged #39. The issue prevents synthesis.