### PR TITLE
Conflict degree sort after priority topological sort

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,8 @@ dependencies = [
     "amaranth == 0.5.3",
     "amaranth-stubs @ git+https://github.com/kuznia-rdzeni/amaranth-stubs.git@481b28c70812936d067e93e4e4cf2eb34bcc50d3",
     "dataclasses-json == 0.6.3",
-    "tabulate == 0.9.0"
+    "tabulate == 0.9.0",
+    "networkx == 3.4.2"
 ]
 requires-python = ">=3.11"
 classifiers = [

--- a/test/core/test_transactions.py
+++ b/test/core/test_transactions.py
@@ -308,10 +308,10 @@ class TestTransactionPriorities(TestCaseWithSimulator):
     def test_unsatisfiable(self, circuit: type[PriorityTestCircuit], priority: Priority):
         m = circuit(priority, True)
 
-        import graphlib
+        import networkx
 
         if priority != Priority.UNDEFINED:
-            cm = pytest.raises(graphlib.CycleError)
+            cm = pytest.raises(networkx.NetworkXUnfeasible)
         else:
             cm = contextlib.nullcontext()
 

--- a/transactron/core/manager.py
+++ b/transactron/core/manager.py
@@ -2,10 +2,10 @@ from collections import defaultdict, deque
 from collections.abc import Callable, Iterable, Sequence, Collection, Mapping
 from typing import TypeAlias, Optional
 from os import environ
-from graphlib import TopologicalSorter
 from amaranth import *
 from amaranth.lib.wiring import Component, connect, flipped
 from itertools import chain, filterfalse, product
+import networkx
 
 from amaranth_types import AbstractComponent
 
@@ -190,7 +190,11 @@ class TransactionManager(Elaboratable):
 
         porder: PriorityOrder = {}
 
-        for k, transaction in enumerate(TopologicalSorter(pgr).static_order()):
+        psorted: list[TBody] = list(
+            networkx.lexicographical_topological_sort(networkx.DiGraph(pgr).reverse(), key=lambda t: len(cgr[t]))
+        )
+
+        for k, transaction in enumerate(psorted):
             porder[transaction] = k
 
         return cgr, porder

--- a/transactron/core/manager.py
+++ b/transactron/core/manager.py
@@ -191,7 +191,7 @@ class TransactionManager(Elaboratable):
         porder: PriorityOrder = {}
 
         psorted: list[TBody] = list(
-            networkx.lexicographical_topological_sort(networkx.DiGraph(pgr).reverse(), key=lambda t: -len(cgr[t]))
+            networkx.lexicographical_topological_sort(networkx.DiGraph(pgr).reverse(), key=lambda t: len(cgr[t]))
         )
 
         for k, transaction in enumerate(psorted):

--- a/transactron/core/manager.py
+++ b/transactron/core/manager.py
@@ -191,7 +191,7 @@ class TransactionManager(Elaboratable):
         porder: PriorityOrder = {}
 
         psorted: list[TBody] = list(
-            networkx.lexicographical_topological_sort(networkx.DiGraph(pgr).reverse(), key=lambda t: len(cgr[t]))
+            networkx.lexicographical_topological_sort(networkx.DiGraph(pgr).reverse(), key=lambda t: -len(cgr[t]))
         )
 
         for k, transaction in enumerate(psorted):


### PR DESCRIPTION
Currently, transactions which do not have priority relations have arbitrary scheduling order. This PR changes it so that the transactions with less conflicts are scheduled first. This should lead to granting transactions more greedily, which has the potential to improve performance. In practice, in current Coreblocks, some IPC numbers are improved, and some get slightly smaller. But still, I think having more determinism in the transaction scheduler is a good thing, as this will reduce weird performance changes on seemingly unrelated refactors, for example.

A new dependency is added, but given that Transactron relies heavily on graphs, `networkx` seems like a dependency that might be useful in the future (for example, for #13).