### PR TITLE
Fix make_hashable

### DIFF
--- a/transactron/utils/data_repr.py
+++ b/transactron/utils/data_repr.py
@@ -24,12 +24,16 @@ def layout_subset(layout: StructLayout, *, fields: set[str]) -> StructLayout:
 
 
 def make_hashable(val) -> Hashable:
-    if isinstance(val, Mapping):
-        return frozenset(((k, make_hashable(v)) for k, v in val.items()))
-    elif isinstance(val, Iterable):
-        return tuple(make_hashable(v) for v in val)
-    else:
+    try:
+        hash(val)
         return val
+    except TypeError:
+        if isinstance(val, Mapping):
+            return frozenset(((k, make_hashable(v)) for k, v in val.items()))
+        elif isinstance(val, Iterable):
+            return tuple(make_hashable(v) for v in val)
+        else:
+            raise
 
 
 def align_to_power_of_two(num: int, power: int) -> int:


### PR DESCRIPTION
Recent change to `make_hashable` (#57) made things worse because of the good old "string is iterable but elements are one-character strings" problem. The old version failed silently (returned a generator with potentially unreliable hashes) on strings, the one in #57 causes a stack overflow. The version in this PR should work correctly for strings and also raises an exception in troublesome cases.