### PR TITLE
Min value

### DIFF
--- a/test/utils/amaranth_ext/test_min_value.py
+++ b/test/utils/amaranth_ext/test_min_value.py
@@ -1,0 +1,36 @@
+from transactron.testing import *
+from transactron.utils.amaranth_ext import min_value
+import random
+
+
+class MinValueCircuit(Elaboratable):
+    def __init__(self, bits: int, num: int):
+        self.inputs = [Signal(bits) for _ in range(num)]
+        self.output = Signal(bits)
+
+    def elaborate(self, platform):
+        m = Module()
+        
+        m.d.comb += self.output.eq(min_value(m, self.inputs))
+
+        return m
+
+
+class TestMinValue(TestCaseWithSimulator):
+    def test_min_value(self):
+        bits = 4
+        num = 3
+        num_tests = 100
+
+        circ = MinValueCircuit(bits, num)
+
+        async def testbench(sim: TestbenchContext):
+            for _ in range(num_tests):
+                vals = [random.randrange(2**bits) for _ in circ.inputs]
+                for sig, val in zip(circ.inputs, vals):
+                    sim.set(sig, val)
+                assert sim.get(circ.output) == min(vals)
+                await sim.tick()
+
+        with self.run_simulation(circ) as sim:
+            sim.add_testbench(testbench)

--- a/test/utils/amaranth_ext/test_min_value.py
+++ b/test/utils/amaranth_ext/test_min_value.py
@@ -10,7 +10,7 @@ class MinValueCircuit(Elaboratable):
 
     def elaborate(self, platform):
         m = Module()
-        
+
         m.d.comb += self.output.eq(min_value(m, self.inputs))
 
         return m

--- a/test/utils/test_component_interface.py
+++ b/test/utils/test_component_interface.py
@@ -36,6 +36,7 @@ class TestComponentInterface(TestCase):
                 super().__init__({"iface": In(TBInterface().signature)})
 
         t = TestComponent()
+        t._MustUse__silence = True  # type: ignore
 
         assert isinstance(t.iface.i, Signal)
         assert isinstance(t.iface.s.i, Signal)

--- a/transactron/core/body.py
+++ b/transactron/core/body.py
@@ -51,10 +51,13 @@ class Body(TransactionBase["Body"]):
         super().__init__(src_loc=src_loc)
 
         def default_combiner(m: Module, args: Sequence[MethodStruct], runs: Value) -> AssignArg:
-            ret = Signal(from_method_layout(i))
-            for k in OneHotSwitchDynamic(m, runs):
-                m.d.comb += ret.eq(args[k])
-            return ret
+            if len(args) == 1:
+                return args[0]
+            else:
+                ret = Signal(from_method_layout(i))
+                for k in OneHotSwitchDynamic(m, runs):
+                    m.d.comb += ret.eq(args[k])
+                return ret
 
         self.def_order = next(Body.def_counter)
         self.name = name

--- a/transactron/core/manager.py
+++ b/transactron/core/manager.py
@@ -224,15 +224,9 @@ class TransactionManager(Elaboratable):
         runs = defaultdict[MBody, list[Value]](list)
 
         for source in method_map.methods_and_transactions:
-            if source in method_map.methods:
-                run_val = Cat(transaction.run for transaction in method_map.transactions_by_method[MBody(source)]).any()
-                run = Signal()
-                m.d.comb += run.eq(run_val)
-            else:
-                run = source.run
             for method, (arg, _) in source.method_uses.items():
                 args[method._body].append(arg)
-                runs[method._body].append(run)
+                runs[method._body].append(source.run)
 
         return (args, runs)
 
@@ -372,14 +366,10 @@ class TransactionManager(Elaboratable):
         (method_args, method_runs) = self._method_calls(m, method_map)
 
         for method in method_map.methods:
-            if len(method_args[method]) == 1:
-                m.d.comb += method.data_in.eq(method_args[method][0])
-            else:
-                if method.single_caller:
-                    raise RuntimeError(f"Single-caller method '{method.name}' called more than once")
-
-                runs = Cat(method_runs[method])
-                m.d.comb += assign(method.data_in, method.combiner(m, method_args[method], runs), fields=AssignType.ALL)
+            if method.single_caller and len(method_args[method]) > 1:
+                raise RuntimeError(f"Single-caller method '{method.name}' called more than once")
+            runs = Cat(method_runs[method])
+            m.d.comb += assign(method.data_in, method.combiner(m, method_args[method], runs), fields=AssignType.ALL)
 
         m.submodules._transactron_schedulers = ModuleConnector(
             *[self.cc_scheduler(method_map, cgr, cc, porder) for cc in ccs]

--- a/transactron/core/manager.py
+++ b/transactron/core/manager.py
@@ -224,9 +224,9 @@ class TransactionManager(Elaboratable):
         runs = defaultdict[MBody, list[Value]](list)
 
         for source in method_map.methods_and_transactions:
-            for method, (arg, _) in source.method_uses.items():
+            for method, (arg, enable) in source.method_uses.items():
                 args[method._body].append(arg)
-                runs[method._body].append(source.run)
+                runs[method._body].append(source.run & enable)
 
         return (args, runs)
 

--- a/transactron/utils/amaranth_ext/functions.py
+++ b/transactron/utils/amaranth_ext/functions.py
@@ -17,7 +17,7 @@ __all__ = [
     "flatten_signals",
     "shape_of",
     "const_of",
-    "min_value"
+    "min_value",
 ]
 
 


### PR DESCRIPTION
This PR adds a function `min_value`, which finds the minimum value of some set of values. The algorithm used is inspired by I2C's arbitration protocol: bits are checked sequentially from MSB to LSB, and if some value has a 0 on a given position, then all values with 1 are excluded from further checks.

Based on #59.