### PR TITLE
Superscalar metrics

### DIFF
--- a/test/lib/test_metrics.py
+++ b/test/lib/test_metrics.py
@@ -26,7 +26,7 @@ class CounterInMethodCircuit(Elaboratable):
 
         @def_method(m, self.method)
         def _():
-            self.counter.incr(m)
+            self.counter.incr[0](m)
 
         return m
 
@@ -43,7 +43,7 @@ class CounterWithConditionInMethodCircuit(Elaboratable):
 
         @def_method(m, self.method)
         def _(cond):
-            self.counter.incr(m, cond=cond)
+            self.counter.incr[0](m, enable_call=cond)
 
         return m
 
@@ -59,7 +59,7 @@ class CounterWithoutMethodCircuit(Elaboratable):
         m.submodules.counter = self.counter
 
         with Transaction().body(m):
-            self.counter.incr(m, cond=self.cond)
+            self.counter.incr[0](m, enable_call=self.cond)
 
         return m
 
@@ -155,7 +155,7 @@ class TaggedCounterCircuit(Elaboratable):
         m.submodules.counter = self.counter
 
         with Transaction().body(m):
-            self.counter.incr(m, self.tag, cond=self.cond)
+            self.counter.incr(m, tag=self.tag, enable_call=self.cond)
 
         return m
 
@@ -335,7 +335,7 @@ class TestFIFOLatencyMeasurer(TestLatencyMeasurerBase):
             ticks = DependencyContext.get().get_dependency(TicksKey())
 
             for _ in range(200):
-                await m._start.call(sim)
+                await m.start[0].call(sim)
 
                 event_queue.put(sim.get(ticks))
                 await self.random_wait_geom(sim, 0.8)
@@ -346,7 +346,7 @@ class TestFIFOLatencyMeasurer(TestLatencyMeasurerBase):
             ticks = DependencyContext.get().get_dependency(TicksKey())
 
             while not finish:
-                await m._stop.call(sim)
+                await m.stop[0].call(sim)
 
                 latencies.append(sim.get(ticks) - event_queue.get())
 
@@ -396,7 +396,7 @@ class TestIndexedLatencyMeasurer(TestLatencyMeasurerBase):
                 await sim.delay(1e-9)
 
                 slot_id = random.choice(free_slots)
-                await m._start.call(sim, slot=slot_id)
+                await m.start[0].call(sim, slot=slot_id)
 
                 events[slot_id] = sim.get(tick_count)
                 free_slots.remove(slot_id)
@@ -415,7 +415,7 @@ class TestIndexedLatencyMeasurer(TestLatencyMeasurerBase):
 
                 slot_id = random.choice(used_slots)
 
-                await m._stop.call(sim, slot=slot_id)
+                await m.stop[0].call(sim, slot=slot_id)
 
                 await sim.delay(2e-9)
 
@@ -447,9 +447,9 @@ class MetricManagerTestCircuit(Elaboratable):
 
         @def_method(m, self.incr_counters)
         def _(counter1, counter2, counter3):
-            self.counter1.incr(m, cond=counter1)
-            self.counter2.incr(m, cond=counter2)
-            self.counter3.incr(m, cond=counter3)
+            self.counter1.incr[0](m, enable_call=counter1)
+            self.counter2.incr[0](m, enable_call=counter2)
+            self.counter3.incr[0](m, enable_call=counter3)
 
         return m
 

--- a/test/lib/test_metrics.py
+++ b/test/lib/test_metrics.py
@@ -155,7 +155,7 @@ class TaggedCounterCircuit(Elaboratable):
         m.submodules.counter = self.counter
 
         with Transaction().body(m):
-            self.counter.incr(m, tag=self.tag, enable_call=self.cond)
+            self.counter.incr(m, self.tag, enable_call=self.cond)
 
         return m
 

--- a/transactron/core/manager.py
+++ b/transactron/core/manager.py
@@ -437,7 +437,7 @@ class TransactionManager(Elaboratable):
 
         return graph
 
-    def debug_signals(self) -> SignalBundle:
+    def debug_signals(self) -> ValueBundle:
         method_map = MethodMap(self.transactions)
         cgr, _ = TransactionManager._conflict_graph(method_map)
 

--- a/transactron/core/method.py
+++ b/transactron/core/method.py
@@ -318,7 +318,7 @@ class Method(TransactionBase["Transaction | Method"]):
     def __repr__(self) -> str:
         return "(method {})".format(self.name)
 
-    def debug_signals(self) -> SignalBundle:
+    def debug_signals(self) -> ValueBundle:
         return [self.ready, self.run, self.data_in, self.data_out]
 
 
@@ -364,5 +364,5 @@ class Methods(Sequence[Method]):
     def __len__(self) -> int:
         return len(self._methods)
 
-    def debug_signals(self) -> SignalBundle:
+    def debug_signals(self) -> ValueBundle:
         return {method.name: method.debug_signals() for method in self._methods}

--- a/transactron/core/method.py
+++ b/transactron/core/method.py
@@ -243,7 +243,7 @@ class Method(TransactionBase["Transaction | Method"]):
         manager._add_method(self)
 
     def __call__(
-        self, m: TModule, arg: Optional[AssignArg] = None, enable: ValueLike = C(1), /, **kwargs: AssignArg
+        self, m: TModule, arg: Optional[AssignArg] = None, /, enable_call: ValueLike = C(1), **kwargs: AssignArg
     ) -> MethodStruct:
         """Call a method.
 
@@ -261,7 +261,7 @@ class Method(TransactionBase["Transaction | Method"]):
             Call argument. Can be passed as a `View` of the method's
             input layout or as a dictionary. Alternative syntax uses
             keyword arguments.
-        enable : Value
+        enable_call : Value
             Configures the call as enabled in the current clock cycle.
             Disabled calls still lock the called method in transaction
             scheduling. Calls are by default enabled.
@@ -300,7 +300,7 @@ class Method(TransactionBase["Transaction | Method"]):
             arg = kwargs
 
         enable_sig = Signal(name=self.owned_name + "_enable")
-        m.d.av_comb += enable_sig.eq(enable)
+        m.d.av_comb += enable_sig.eq(enable_call)
         m.d.top_comb += assign(arg_rec, arg, fields=AssignType.ALL)
 
         caller = Body.get()
@@ -346,11 +346,11 @@ class Methods(Sequence[Method]):
         return self._layout_out
 
     def __call__(
-        self, m: TModule, arg: Optional[AssignArg] = None, enable: ValueLike = C(1), /, **kwargs: AssignArg
+        self, m: TModule, arg: Optional[AssignArg] = None, /, enable_call: ValueLike = C(1), **kwargs: AssignArg
     ) -> MethodStruct:
         if len(self._methods) != 1:
             raise RuntimeError("calling Methods only allowed when count=1")
-        return self._methods[0](m, arg, enable, **kwargs)
+        return self._methods[0](m, arg, enable_call, **kwargs)
 
     @overload
     def __getitem__(self, key: int) -> Method: ...

--- a/transactron/core/transaction.py
+++ b/transactron/core/transaction.py
@@ -132,5 +132,5 @@ class Transaction(TransactionBase["Transaction | Method"]):
     def __repr__(self) -> str:
         return "(transaction {})".format(self.name)
 
-    def debug_signals(self) -> SignalBundle:
+    def debug_signals(self) -> ValueBundle:
         return [self.request, self.runnable, self.grant]

--- a/transactron/lib/adapters.py
+++ b/transactron/lib/adapters.py
@@ -6,7 +6,7 @@ from amaranth.lib.data import StructLayout, View
 
 from ..utils import SrcLoc, get_src_loc, MethodStruct
 from ..core import *
-from ..utils._typing import SignalBundle, MethodLayout
+from ..utils._typing import ValueBundle, MethodLayout
 
 __all__ = [
     "AdapterBase",
@@ -25,7 +25,7 @@ class AdapterBase(Component):
         super().__init__({"data_in": In(layout_in), "data_out": Out(layout_out), "en": In(1), "done": Out(1)})
         self.iface = iface
 
-    def debug_signals(self) -> SignalBundle:
+    def debug_signals(self) -> ValueBundle:
         return [self.en, self.done, self.data_in, self.data_out]
 
     @abstractmethod

--- a/transactron/lib/metrics.py
+++ b/transactron/lib/metrics.py
@@ -374,8 +374,6 @@ class TaggedCounter(Elaboratable, HwMetric):
         Transactron module
     tag: ValueLike
         The tag of the counter.
-    cond: ValueLike
-        When set to high, the counter will be increased. By default set to high.
     """
 
 

--- a/transactron/lib/metrics.py
+++ b/transactron/lib/metrics.py
@@ -14,7 +14,6 @@ from transactron.lib import FIFO, AsyncMemoryBank, logging
 from transactron.utils._typing import MethodStruct
 from transactron.utils.amaranth_ext.functions import max_value, min_value, sum_value, popcount
 from transactron.utils.dependencies import ListKey, DependencyContext, SimpleKey
-from transactron.utils.transactron_helpers import make_layout
 
 __all__ = [
     "MetricRegisterModel",
@@ -677,7 +676,7 @@ class TaggedLatencyMeasurer(Elaboratable):
         epoch_width = bits_for(self.max_latency)
 
         m.submodules.slots = self.slots = AsyncMemoryBank(
-            shape=make_layout(("epoch", epoch_width)),
+            shape=epoch_width,
             depth=self.slots_number,
             write_ports=len(self.start),
             read_ports=len(self.stop),
@@ -709,7 +708,7 @@ class TaggedLatencyMeasurer(Elaboratable):
             ret = self.slots.read[k](m, addr=slot)
             # The result of substracting two unsigned n-bit is a signed (n+1)-bit value,
             # so we need to cast the result and discard the most significant bit.
-            duration = (epoch - ret.data.epoch).as_unsigned()[:-1]
+            duration = (epoch - ret.data).as_unsigned()[:-1]
             self.histogram.add[k](m, duration)
 
         return m

--- a/transactron/lib/metrics.py
+++ b/transactron/lib/metrics.py
@@ -567,9 +567,9 @@ class FIFOLatencyMeasurer(Elaboratable):
 
         epoch_width = bits_for(self.max_latency)
 
-        self.fifos: list[FIFO] = []
+        self.fifos = [FIFO([("epoch", epoch_width)], self.slots_number) for _ in range(len(self.start))]
         for k in range(len(self.start)):
-            m.submodules[f"fifo{k}"] = self.fifos[k] = FIFO([("epoch", epoch_width)], self.slots_number)
+            m.submodules[f"fifo{k}"] = self.fifos[k]
 
         m.submodules.histogram = self.histogram
 

--- a/transactron/lib/storage.py
+++ b/transactron/lib/storage.py
@@ -72,15 +72,14 @@ class MemoryBank(Elaboratable):
         self.shape = shape
         self.depth = depth
         self.granularity = granularity
-        self.addr_width = bits_for(self.depth - 1)
         self.transparent = transparent
         self.reads_ports = read_ports
         self.writes_ports = write_ports
         self.memory_type = memory_type
 
-        self.read_reqs_layout: LayoutList = [("addr", self.addr_width)]
+        self.read_reqs_layout: LayoutList = [("addr", range(self.depth))]
         self.read_resps_layout = make_layout(("data", self.shape))
-        write_layout = [("addr", self.addr_width), ("data", self.shape)]
+        write_layout = [("addr", range(self.depth)), ("data", self.shape)]
         if self.granularity is not None:
             # use Amaranth lib.memory granularity rule checks and width
             amaranth_write_port_sig = memory.WritePort.Signature(
@@ -299,14 +298,13 @@ class AsyncMemoryBank(Elaboratable):
         self.shape = shape
         self.depth = depth
         self.granularity = granularity
-        self.addr_width = bits_for(self.depth - 1)
         self.reads_ports = read_ports
         self.writes_ports = write_ports
         self.memory_type = memory_type
 
-        self.read_reqs_layout: LayoutList = [("addr", self.addr_width)]
+        self.read_reqs_layout: LayoutList = [("addr", range(self.depth))]
         self.read_resps_layout: LayoutList = [("data", self.shape)]
-        write_layout = [("addr", self.addr_width), ("data", self.shape)]
+        write_layout = [("addr", range(self.depth)), ("data", self.shape)]
         if self.granularity is not None:
             # use Amaranth lib.memory granularity rule checks and width
             amaranth_write_port_sig = memory.WritePort.Signature(

--- a/transactron/testing/infrastructure.py
+++ b/transactron/testing/infrastructure.py
@@ -342,9 +342,11 @@ class TestCaseWithSimulator:
         """
         await self.tick(sim, random.randrange(min_cycle_cnt, max_cycle_cnt + 1))
 
-    async def random_wait_geom(self, sim: SimulatorContext, prob: float = 0.5):
+    async def random_wait_geom(self, sim: SimulatorContext, prob: float = 0.5, max_cycle_cnt: int = 2**16):
         """
         Wait till the first success, where there is `prob` probability for success in each cycle.
         """
-        while random.random() > prob:
+        cycle_cnt = 0
+        while random.random() > prob and cycle_cnt < max_cycle_cnt:
             await sim.tick()
+            cycle_cnt += 1

--- a/transactron/utils/_typing.py
+++ b/transactron/utils/_typing.py
@@ -25,7 +25,7 @@ __all__ = [
     "SrcLoc",
     "MethodLayout",
     "MethodStruct",
-    "SignalBundle",
+    "ValueBundle",
     "LayoutListField",
     "LayoutList",
     "LayoutIterable",
@@ -43,7 +43,7 @@ __all__ = [
 ]
 
 # Internal Coreblocks types
-SignalBundle: TypeAlias = Signal | Record | View | Iterable["SignalBundle"] | Mapping[str, "SignalBundle"]
+ValueBundle: TypeAlias = Value | Record | View | Iterable["ValueBundle"] | Mapping[str, "ValueBundle"]
 LayoutListField: TypeAlias = tuple[str, "ShapeLike | LayoutList"]
 LayoutList: TypeAlias = list["LayoutListField"]
 LayoutIterable: TypeAlias = Iterable["LayoutListField"]
@@ -66,7 +66,7 @@ GraphCC: TypeAlias = set[T]
 
 @runtime_checkable
 class HasDebugSignals(Protocol):
-    def debug_signals(self) -> SignalBundle: ...
+    def debug_signals(self) -> ValueBundle: ...
 
 
 def type_self_kwargs_as(as_func: Callable[Concatenate[Any, P], Any]):

--- a/transactron/utils/amaranth_ext/functions.py
+++ b/transactron/utils/amaranth_ext/functions.py
@@ -19,6 +19,7 @@ __all__ = [
     "shape_of",
     "const_of",
     "binary_tree_reduce",
+    "sum_value",
     "generic_min_value",
     "min_value",
     "max_value",
@@ -149,6 +150,10 @@ def binary_tree_reduce(*values: ValueBundle, neutral: Value, operator: Callable[
         min_layers = [operator(a, b) for a, b in zip(min_layers[::2], min_layers[1::2])] + tail
 
     return min_layers[0]
+
+
+def sum_value(*values: ValueBundle):
+    return binary_tree_reduce(*values, neutral=C(0), operator=operator.add)
 
 
 def generic_min_value(*values: ValueBundle, operator: Callable[[Value, Value], Value]) -> Value:

--- a/transactron/utils/amaranth_ext/functions.py
+++ b/transactron/utils/amaranth_ext/functions.py
@@ -3,10 +3,11 @@ from amaranth import *
 from amaranth.hdl import ShapeCastable, ValueCastable
 from amaranth.utils import bits_for, ceil_log2
 from amaranth.lib import data
-from collections.abc import Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping
+import operator
 
 from amaranth_types.types import ValueLike, ShapeLike
-from transactron.utils._typing import SignalBundle
+from transactron.utils._typing import ValueBundle
 
 __all__ = [
     "mod_incr",
@@ -17,6 +18,10 @@ __all__ = [
     "flatten_signals",
     "shape_of",
     "const_of",
+    "binary_tree_reduce",
+    "generic_min_value",
+    "min_value",
+    "max_value",
 ]
 
 
@@ -97,7 +102,7 @@ def cyclic_mask(bits: int, start: Value, end: Value):
     return Mux(start <= end, mask_se, mask_es)
 
 
-def flatten_signals(signals: SignalBundle) -> Iterable[Signal]:
+def flatten_signals(signals: ValueBundle) -> Iterable[Value]:
     """
     Flattens input data, which can be either a signal, a record, a list (or a dict) of SignalBundle items.
 
@@ -132,3 +137,30 @@ def const_of(value: int, shape: ShapeLike) -> Any:
         return shape.from_bits(value)
     else:
         return C(value, Shape.cast(shape))
+
+
+def binary_tree_reduce(*values: ValueBundle, neutral: Value, operator: Callable[[Value, Value], Value]) -> Value:
+    min_layers = list(flatten_signals(values))
+    if not min_layers:
+        min_layers.append(neutral)
+
+    while len(min_layers) > 1:
+        tail = [min_layers[-1]] if len(min_layers) % 2 else []
+        min_layers = [operator(a, b) for a, b in zip(min_layers[::2], min_layers[1::2])] + tail
+
+    return min_layers[0]
+
+
+def generic_min_value(*values: ValueBundle, operator: Callable[[Value, Value], Value]) -> Value:
+    def binary_min(v1: Value, v2: Value):
+        return Mux(operator(v1, v2), v1, v2)
+
+    return binary_tree_reduce(*values, neutral=C(0), operator=binary_min)
+
+
+def min_value(*values: ValueBundle) -> Value:
+    return generic_min_value(*values, operator=operator.lt)
+
+
+def max_value(*values: ValueBundle) -> Value:
+    return generic_min_value(*values, operator=operator.gt)

--- a/transactron/utils/amaranth_ext/functions.py
+++ b/transactron/utils/amaranth_ext/functions.py
@@ -20,6 +20,8 @@ __all__ = [
     "const_of",
     "binary_tree_reduce",
     "sum_value",
+    "or_value",
+    "and_value",
     "generic_min_value",
     "min_value",
     "max_value",
@@ -154,6 +156,14 @@ def binary_tree_reduce(*values: ValueBundle, neutral: Value, operator: Callable[
 
 def sum_value(*values: ValueBundle):
     return binary_tree_reduce(*values, neutral=C(0), operator=operator.add)
+
+
+def or_value(*values: ValueBundle):
+    return binary_tree_reduce(*values, neutral=C(0), operator=operator.or_)
+
+
+def and_value(*values: ValueBundle):
+    return binary_tree_reduce(*values, neutral=C(-1), operator=operator.and_)
 
 
 def generic_min_value(*values: ValueBundle, operator: Callable[[Value, Value], Value]) -> Value:

--- a/transactron/utils/debug_signals.py
+++ b/transactron/utils/debug_signals.py
@@ -1,13 +1,13 @@
 from typing import Optional
 from amaranth import *
-from ._typing import SignalBundle, HasDebugSignals
+from ._typing import ValueBundle, HasDebugSignals
 from collections.abc import Collection, Mapping
 
 
 __all__ = ["auto_debug_signals"]
 
 
-def auto_debug_signals(thing) -> SignalBundle:
+def auto_debug_signals(thing) -> ValueBundle:
     """Automatic debug signal generation.
 
     Exposes class attributes with debug signals (Amaranth `Signal`\\s,
@@ -16,12 +16,12 @@ def auto_debug_signals(thing) -> SignalBundle:
     tests, for use in ``gtkwave``.
     """
 
-    def auto_debug_signals_internal(thing, *, _visited: set) -> Optional[SignalBundle]:
+    def auto_debug_signals_internal(thing, *, _visited: set) -> Optional[ValueBundle]:
         # Please note, that the set `_visited` is used to memorise visited elements
         # to break reference cycles. There is only one instance of this set, for whole
         # `auto_debug_signals` recursion stack. It is being mutated by adding to it more
         # elements id, so that caller know what was visited by callee.
-        smap: dict[str, SignalBundle] = {}
+        smap: dict[str, ValueBundle] = {}
 
         # Check for reference cycles e.g. Amaranth's MustUse
         if id(thing) in _visited:


### PR DESCRIPTION
This PR modifies metrics to enable superscalar use - changing a metric multiple times in a single clock cycle. This is needed to be able to create superscalar circuits which utilize metrics.

The PR introduces a small syntactic change to method calls: the `enable` signal is renamed to `enable_call` and can be used as a keyword argument. This means that `enable_call` is now a reserved argument name. This was done to be able to remove method wrapper functions from metrics modules, which utilized an optional `cond` argument - which is basically `enable`. I'm not extra happy with the solution, but it gets the job done.

TODO:
* [x] Update metrics tests to test superscalar use.