### PR TITLE
Testpypi fix

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -20,6 +20,9 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
+    - name: Omit local version for Test PyPI upload
+      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+      run: echo SETUPTOOLS_SCM_OVERRIDES_FOR_TRANSACTRON='{local_scheme="no-local-version"}' >> $GITHUB_ENV
     - name: Install pypa/build
       run: python3 -m pip install build --user
     - name: Build a binary wheel and a source tarball
@@ -70,6 +73,7 @@ jobs:
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
+        skip-existing: true
         repository-url: https://test.pypi.org/legacy/
 
   github-release:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ build-backend = "setuptools.build_meta"
 name = "transactron"
 dynamic = ["version"]
 dependencies = [
-    "amaranth == 0.5.3",
-    "amaranth-stubs @ git+https://github.com/kuznia-rdzeni/amaranth-stubs.git@481b28c70812936d067e93e4e4cf2eb34bcc50d3",
+    "amaranth == 0.5.4",
+    "amaranth-stubs == 0.1.1",
     "dataclasses-json == 0.6.3",
     "tabulate == 0.9.0",
     "networkx == 3.4.2"


### PR DESCRIPTION
This PR fixes publishing to TestPyPI by changing the way `setuptools_scm` generates version numbers. The `amaranth-stubs` dependency is changed to a PyPI published version to allow deployment to PyPI and TestPyPI.