### PR TITLE
Optional write width in WideFifo

### DIFF
--- a/transactron/lib/fifo.py
+++ b/transactron/lib/fifo.py
@@ -145,7 +145,13 @@ class WideFifo(Elaboratable):
     """
 
     def __init__(
-        self, shape: ShapeLike, depth: int, read_width: int, write_width: Optional[int], *, src_loc: int | SrcLoc = 0
+        self,
+        shape: ShapeLike,
+        depth: int,
+        read_width: int,
+        write_width: Optional[int] = None,
+        *,
+        src_loc: int | SrcLoc = 0,
     ) -> None:
         """
         Parameters


### PR DESCRIPTION
This PR makes the `write_width` parameter, which is documented as optional, actually optional.