### PR TITLE
Add a way to access WideFifo data from simulation

### DIFF
--- a/test/lib/test_fifo.py
+++ b/test/lib/test_fifo.py
@@ -111,7 +111,8 @@ class TestWideFifo(TestCaseWithSimulator):
 
         self.shape = shape
         self.bits = Shape.cast(shape).width
-        self.circ = SimpleTestCircuit(WideFifo(shape, depth, read_width, write_width))
+        max_width = max(read_width, write_width)
+        self.circ = SimpleTestCircuit(WideFifo(shape, depth * max_width, read_width, write_width))
         self.read_width = read_width
         self.write_width = write_width
 


### PR DESCRIPTION
This is to help with ROB testing in Coreblocks, see https://github.com/kuznia-rdzeni/coreblocks/pull/819.