### PR TITLE
Allow Serializer to have non-power-of-2 number of ports

### DIFF
--- a/test/lib/test_reqres.py
+++ b/test/lib/test_reqres.py
@@ -2,6 +2,7 @@ import random
 from collections import deque
 
 from amaranth import *
+import pytest
 from transactron import *
 from transactron.lib.adapters import Adapter
 from transactron.lib.reqres import *
@@ -16,11 +17,13 @@ from transactron.testing import (
 )
 
 
+@pytest.mark.parametrize("port_count", [2, 3])
 class TestSerializer(TestCaseWithSimulator):
-    def setup_method(self):
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_method(self, port_count: int):
         self.test_count = 100
 
-        self.port_count = 2
+        self.port_count = port_count
         self.data_width = 5
 
         self.requestor_rand = 4
@@ -83,8 +86,8 @@ class TestSerializer(TestCaseWithSimulator):
 
         return f
 
-    def test_serial(self):
+    def test_serial(self, port_count: int):
         with self.run_simulation(self.m) as sim:
-            for i in range(self.port_count):
+            for i in range(port_count):
                 sim.add_testbench(self.requestor(i))
                 sim.add_testbench(self.responder(i))

--- a/transactron/lib/reqres.py
+++ b/transactron/lib/reqres.py
@@ -159,7 +159,7 @@ class Serializer(Elaboratable):
 
         self.depth = depth
 
-        self.id_layout = [("id", exact_log2(self.port_count))]
+        self.id_layout = [("id", range(self.port_count))]
 
         self.clear = Method()
         self.serialize_in = Methods(port_count, i=serialized_req_method.layout_in, src_loc=self.src_loc)


### PR DESCRIPTION
The use of `exact_log2` in `Serializer` introduces an unnecessary and undocumented power-of-2 requirement on the port count. This PR fixes that.