### PR TITLE
Remove module argument from Method.proxy

### DIFF
--- a/test/test_simultaneous.py
+++ b/test/test_simultaneous.py
@@ -129,8 +129,8 @@ class TransitivityTestCircuit(Elaboratable):
 
         m.submodules.c1 = c1 = Connect([("data", 2)])
         m.submodules.c2 = c2 = Connect([("data", 2)])
-        self.source1.proxy(m, c1.write)
-        self.source2.proxy(m, c1.write)
+        self.source1.proxy(c1.write)
+        self.source2.proxy(c1.write)
         m.submodules.ct = ConnectTrans(c2.read, self.target)
         m.submodules.hc1 = HelperConnect(c1.read, c2.write, self.req1, 1)
         m.submodules.hc2 = HelperConnect(c1.read, c2.write, self.req2, 2)

--- a/transactron/core/method.py
+++ b/transactron/core/method.py
@@ -137,18 +137,14 @@ class Method(TransactionBase["Transaction | Method"]):
             return self._body_ptr
         raise RuntimeError(f"Method '{self.name}' not defined")
 
-    def _set_impl(self, m: TModule, value: "Body | Method"):
+    def _set_impl(self, value: "Body | Method"):
         if self._body_ptr is not None:
             raise RuntimeError(f"Method '{self.name}' already defined")
         if value.data_in.shape() != self.layout_in or value.data_out.shape() != self.layout_out:
             raise ValueError(f"Method {value.name} has different interface than {self.name}")
         self._body_ptr = value
-        m.d.comb += self.ready.eq(value.ready)
-        m.d.comb += self.run.eq(value.run)
-        m.d.comb += self.data_in.eq(value.data_in)
-        m.d.comb += self.data_out.eq(value.data_out)
 
-    def proxy(self, m: TModule, method: "Method"):
+    def proxy(self, method: "Method"):
         """Define as a proxy for another method.
 
         The calls to this method will be forwarded to `method`.
@@ -161,7 +157,10 @@ class Method(TransactionBase["Transaction | Method"]):
         method : Method
             Method for which this method is a proxy for.
         """
-        self._set_impl(m, method)
+        self._set_impl(method)
+
+        manager = DependencyContext.get().get_dependency(TransactionManagerKey())
+        manager._add_proxy_method(self)
 
     @contextmanager
     def body(
@@ -231,7 +230,7 @@ class Method(TransactionBase["Transaction | Method"]):
         body = Body(
             name=self.name, owner=self.owner, i=self.layout_in, o=self.layout_out, src_loc=self.src_loc, **kwargs
         )
-        self._set_impl(m, body)
+        self._set_impl(body)
 
         m.d.av_comb += body.ready.eq(ready)
         m.d.top_comb += body.data_out.eq(out)

--- a/transactron/lib/reqres.py
+++ b/transactron/lib/reqres.py
@@ -97,7 +97,7 @@ class ArgumentsToResultsZipper(Elaboratable):
             results = forwarder.read(m)
             return {"args": args, "results": results}
 
-        self.peek_arg.proxy(m, fifo.peek)
+        self.peek_arg.proxy(fifo.peek)
 
         return m
 
@@ -183,6 +183,6 @@ class Serializer(Elaboratable):
                 pending_requests.read(m)
                 return self.serialized_resp_method(m)
 
-        self.clear.proxy(m, pending_requests.clear)
+        self.clear.proxy(pending_requests.clear)
 
         return m

--- a/transactron/lib/transformers.py
+++ b/transactron/lib/transformers.py
@@ -361,7 +361,7 @@ class Collector(Elaboratable, Unifier):
             get_results=[get for get in self.method_list], put_result=forwarder.write, src_loc=self.src_loc
         )
 
-        self.method.proxy(m, forwarder.read)
+        self.method.proxy(forwarder.read)
 
         return m
 


### PR DESCRIPTION
This PR removes the need to supply a `TModule` argument to `Method.proxy`. The `ready`, `run` etc. signals are now set from the `TransactionManager`. This will make future API changes simpler. Also, a bug when `proxy` might be called inside `m.If` is fixed.