### PR TITLE
Refactor Transactron context wrappers

### DIFF
--- a/test/core/test_transactions.py
+++ b/test/core/test_transactions.py
@@ -114,7 +114,7 @@ class TransactionConflictTestCircuit(Elaboratable):
 
     def elaborate(self, platform):
         m = TModule()
-        tm = TransactionModule(m, DependencyContext.get(), TransactionManager(self.scheduler))
+        tm = TransactronContextElaboratable(m, DependencyContext.get(), TransactionManager(self.scheduler))
         adapter = Adapter.create(i=data_layout(32), o=data_layout(32))
         m.submodules.out = self.out = TestbenchIO(adapter)
         m.submodules.in1 = self.in1 = TestbenchIO(AdapterTrans(adapter.iface))
@@ -323,7 +323,7 @@ class TestTransactionPriorities(TestCaseWithSimulator):
 class NestedTransactionsTestCircuit(SchedulingTestCircuit):
     def elaborate(self, platform):
         m = TModule()
-        tm = TransactionModule(m)
+        tm = TransactronContextElaboratable(m)
 
         with tm.context():
             with Transaction().body(m, request=self.r1):
@@ -337,7 +337,7 @@ class NestedTransactionsTestCircuit(SchedulingTestCircuit):
 class NestedMethodsTestCircuit(SchedulingTestCircuit):
     def elaborate(self, platform):
         m = TModule()
-        tm = TransactionModule(m)
+        tm = TransactronContextElaboratable(m)
 
         method1 = Method()
         method2 = Method()
@@ -385,7 +385,7 @@ class TestNested(TestCaseWithSimulator):
 class ScheduleBeforeTestCircuit(SchedulingTestCircuit):
     def elaborate(self, platform):
         m = TModule()
-        tm = TransactionModule(m)
+        tm = TransactronContextElaboratable(m)
 
         method = Method()
 

--- a/test/test_branches.py
+++ b/test/test_branches.py
@@ -5,7 +5,7 @@ from transactron.core import (
     Method,
     Transaction,
     TransactionManager,
-    TransactionModule,
+    TransactronContextElaboratable,
     def_method,
 )
 from transactron.core.tmodule import CtrlPath
@@ -88,7 +88,7 @@ class TestExclusiveConflictRemoval(TestCaseWithSimulator):
         circ = ExclusiveConflictRemovalCircuit()
 
         tm = TransactionManager()
-        dut = TransactionModule(circ, DependencyContext.get(), tm)
+        dut = TransactronContextElaboratable(circ, DependencyContext.get(), tm)
 
         with self.run_simulation(dut, add_transaction_module=False):
             pass

--- a/test/test_methods.py
+++ b/test/test_methods.py
@@ -181,7 +181,7 @@ class AdapterCircuit(Elaboratable):
 class TestInvalidMethods(TestCase):
     def assert_re(self, msg, m):
         with pytest.raises(RuntimeError, match=msg):
-            Fragment.get(TransactionModule(m), platform=None)
+            Fragment.get(TransactronContextElaboratable(m), platform=None)
 
     def test_twice(self):
         class Twice(Elaboratable):
@@ -225,7 +225,7 @@ class TestInvalidMethods(TestCase):
 
                 return m
 
-        Fragment.get(TransactionModule(Twice()), platform=None)
+        Fragment.get(TransactronContextElaboratable(Twice()), platform=None)
 
     def test_diamond(self):
         class Diamond(Elaboratable):

--- a/transactron/core/__init__.py
+++ b/transactron/core/__init__.py
@@ -3,5 +3,6 @@ from .transaction_base import *  # noqa: F401
 from .method import *  # noqa: F401
 from .transaction import *  # noqa: F401
 from .manager import *  # noqa: F401
+from .context import *  # noqa: F401
 from .sugar import *  # noqa: F401
 from .body import *  # noqa: F401

--- a/transactron/core/context.py
+++ b/transactron/core/context.py
@@ -10,13 +10,14 @@ from .keys import TransactionManagerKey
 from transactron.utils import DependencyContext, DependencyManager, silence_mustuse
 
 
-__all__ = ["TransactionModule", "TransactionComponent"]
+__all__ = ["TransactronContextElaboratable", "TransactronContextComponent"]
 
 
-class TransactionModule(Elaboratable):
-    """
-    `TransactionModule` is used as wrapper on `Elaboratable` classes,
-    which adds support for transactions. It creates a
+class TransactronContextElaboratable(Elaboratable):
+    """Top-level Elaboratable for Transactron projects.
+
+    `TransactronContextElaboratable` is used as wrapper on `Elaboratable`
+    classes, which adds support for transactions. It creates a
     `TransactionManager` which will handle transaction scheduling
     and can be used in definition of `Method`\\s and `Transaction`\\s.
     The `TransactionManager` is stored in a `DependencyManager`.
@@ -67,16 +68,16 @@ class TransactionModule(Elaboratable):
         return m
 
 
-class TransactionComponent(TransactionModule, Component):
+class TransactronContextComponent(TransactronContextElaboratable, Component):
     """Top-level component for Transactron projects.
 
-    The `TransactronComponent` is a wrapper on `Component` classes,
+    The `TransactronContextComponent` is a wrapper on `Component` classes,
     which adds Transactron support for the wrapped class. The use
     case is to wrap a top-level module of the project, and pass the
     wrapped module for simulation, HDL generation or synthesis.
     The ports of the wrapped component are forwarded to the wrapper.
 
-    It extends the functionality of `TransactionModule`.
+    It extends the functionality of `TransactronContextComponent`.
     """
 
     def __init__(
@@ -98,7 +99,7 @@ class TransactionComponent(TransactionModule, Component):
             The `TransactionManager` to use inside the transaction component.
             If omitted, a new one is created.
         """
-        TransactionModule.__init__(self, component, dependency_manager, transaction_manager)
+        TransactronContextElaboratable.__init__(self, component, dependency_manager, transaction_manager)
         Component.__init__(self, component.signature)
 
     def elaborate(self, platform):

--- a/transactron/core/context.py
+++ b/transactron/core/context.py
@@ -1,0 +1,110 @@
+from typing import Optional
+from amaranth import *
+from amaranth.lib.wiring import Component, connect, flipped
+
+from amaranth_types import AbstractComponent, HasElaborate
+
+from .manager import TransactionManager
+from .keys import TransactionManagerKey
+
+from transactron.utils import DependencyContext, DependencyManager, silence_mustuse
+
+
+__all__ = ["TransactionModule", "TransactionComponent"]
+
+
+class TransactionModule(Elaboratable):
+    """
+    `TransactionModule` is used as wrapper on `Elaboratable` classes,
+    which adds support for transactions. It creates a
+    `TransactionManager` which will handle transaction scheduling
+    and can be used in definition of `Method`\\s and `Transaction`\\s.
+    The `TransactionManager` is stored in a `DependencyManager`.
+    """
+
+    def __init__(
+        self,
+        elaboratable: HasElaborate,
+        dependency_manager: Optional[DependencyManager] = None,
+        transaction_manager: Optional[TransactionManager] = None,
+    ):
+        """
+        Parameters
+        ----------
+        elaboratable: HasElaborate
+            The `Elaboratable` which should be wrapped to add support for
+            transactions and methods.
+        dependency_manager: DependencyManager, optional
+            The `DependencyManager` to use inside the transaction module.
+            If omitted, a new one is created.
+        transaction_manager: TransactionManager, optional
+            The `TransactionManager` to use inside the transaction module.
+            If omitted, a new one is created.
+        """
+        if transaction_manager is None:
+            transaction_manager = TransactionManager()
+        if dependency_manager is None:
+            dependency_manager = DependencyManager()
+        self.manager = dependency_manager
+        self.manager.add_dependency(TransactionManagerKey(), transaction_manager)
+        self.elaboratable = elaboratable
+
+    def context(self) -> DependencyContext:
+        return DependencyContext(self.manager)
+
+    def elaborate(self, platform):
+        with silence_mustuse(self.manager.get_dependency(TransactionManagerKey())):
+            with self.context():
+                elaboratable = Fragment.get(self.elaboratable, platform)
+
+        m = Module()
+
+        m.submodules.main_module = elaboratable
+        m.submodules.transactionManager = self.transaction_manager = self.manager.get_dependency(
+            TransactionManagerKey()
+        )
+
+        return m
+
+
+class TransactionComponent(TransactionModule, Component):
+    """Top-level component for Transactron projects.
+
+    The `TransactronComponent` is a wrapper on `Component` classes,
+    which adds Transactron support for the wrapped class. The use
+    case is to wrap a top-level module of the project, and pass the
+    wrapped module for simulation, HDL generation or synthesis.
+    The ports of the wrapped component are forwarded to the wrapper.
+
+    It extends the functionality of `TransactionModule`.
+    """
+
+    def __init__(
+        self,
+        component: AbstractComponent,
+        dependency_manager: Optional[DependencyManager] = None,
+        transaction_manager: Optional[TransactionManager] = None,
+    ):
+        """
+        Parameters
+        ----------
+        component: Component
+            The `Component` which should be wrapped to add support for
+            transactions and methods.
+        dependency_manager: DependencyManager, optional
+            The `DependencyManager` to use inside the transaction component.
+            If omitted, a new one is created.
+        transaction_manager: TransactionManager, optional
+            The `TransactionManager` to use inside the transaction component.
+            If omitted, a new one is created.
+        """
+        TransactionModule.__init__(self, component, dependency_manager, transaction_manager)
+        Component.__init__(self, component.signature)
+
+    def elaborate(self, platform):
+        m = super().elaborate(platform)
+
+        assert isinstance(self.elaboratable, Component)  # for typing
+        connect(m, flipped(self), self.elaboratable)
+
+        return m

--- a/transactron/testing/infrastructure.py
+++ b/transactron/testing/infrastructure.py
@@ -23,7 +23,7 @@ from .method_mock import MethodMock
 from transactron import Method, Methods
 from transactron.lib import AdapterTrans
 from transactron.core.keys import TransactionManagerKey
-from transactron.core import TransactionModule
+from transactron.core import TransactronContextElaboratable
 from transactron.utils import ModuleConnector, HasElaborate, auto_debug_signals, HasDebugSignals
 
 
@@ -123,7 +123,7 @@ class SimpleTestCircuit(Elaboratable, Generic[_T_HasElaborate]):
 class _TestModule(Elaboratable):
     def __init__(self, tested_module: HasElaborate, add_transaction_module: bool):
         self.tested_module = (
-            TransactionModule(tested_module, dependency_manager=DependencyContext.get())
+            TransactronContextElaboratable(tested_module, dependency_manager=DependencyContext.get())
             if add_transaction_module
             else tested_module
         )


### PR DESCRIPTION
This PR factors out the Transactron context wrappers to a separate file and gives them hopefully less ambiguous names.