### PR TITLE
Rename request/grant to ready/run

### DIFF
--- a/docs/transactions.md
+++ b/docs/transactions.md
@@ -230,12 +230,12 @@ def _(foo: Value, bar: Value):
 
 ### Readiness signals
 
-If a transaction is not always ready for execution (for example, because of the dependence on some resource), a `request` parameter should be used.
+If a transaction is not always ready for execution (for example, because of the dependence on some resource), a `ready` parameter should be used.
 An Amaranth single-bit expression should be passed.
 When the `request` parameter is not passed, the transaction is always requesting execution.
 
 ```python
-        with Transaction().body(m, request=expr):
+        with Transaction().body(m, ready=expr):
 ```
 
 Methods have a similar mechanism, which uses the `ready` parameter on `def_method`:
@@ -246,7 +246,7 @@ Methods have a similar mechanism, which uses the `ready` parameter on `def_metho
             ...
 ```
 
-The `request` signal typically should only depend on the internal state of an `Elaboratable`.
+The `ready` signal typically should only depend on the internal state of an `Elaboratable`.
 Other dependencies risk introducing combinational loops.
 In certain occasions, it is possible to relax this requirement; see e.g. [Scheduling order](#scheduling-order).
 
@@ -270,7 +270,7 @@ Its role is to allow to improve circuit performance by omitting unneeded multipl
 This is done by adding two additional, special combinatorial domains, `av_comb` and `top_comb`.
 
 Statements added to the `av_comb` domain (the "avoiding" domain) are not executed when under a false `m.If`, but are executed when under a false `m.AvoidedIf`.
-Transaction and method bodies are internally guarded by an `m.AvoidedIf` with the transaction `grant` or method `run` signal.
+Transaction and method bodies are internally guarded by an `m.AvoidedIf` with the `run` signal of the transaction or method.
 Therefore combinational assignments added to `av_comb` work even if the transaction or method definition containing the assignments are not running.
 Because combinational signals usually don't induce state changes, this is often safe to do and improves performance.
 

--- a/test/test_methods.py
+++ b/test/test_methods.py
@@ -458,7 +458,7 @@ class ConditionalTransactionCircuit1(Elaboratable):
         self.ready = Signal()
         m.submodules.tb = self.tb = TestbenchIO(Adapter.create())
 
-        with Transaction().body(m, request=self.ready):
+        with Transaction().body(m, ready=self.ready):
             self.tb.adapter.iface(m)
 
         return m
@@ -725,11 +725,11 @@ class DataDependentConditionalCircuit(Elaboratable):
         def _(data):
             m.d.comb += self.out_m.eq(1)
 
-        with Transaction().body(m, request=self.req_t1):
+        with Transaction().body(m, ready=self.req_t1):
             m.d.comb += self.out_t1.eq(1)
             self.method(m, data=self.in_t1)
 
-        with Transaction().body(m, request=self.req_t2):
+        with Transaction().body(m, ready=self.req_t2):
             m.d.comb += self.out_t2.eq(1)
             self.method(m, data=self.in_t2)
 

--- a/test/test_simultaneous.py
+++ b/test/test_simultaneous.py
@@ -101,16 +101,16 @@ class TestUnsatisfiableTriangle(TestCaseWithSimulator):
 
 
 class HelperConnect(Elaboratable):
-    def __init__(self, source: Method, target: Method, request: Signal, data: int):
+    def __init__(self, source: Method, target: Method, ready: Signal, data: int):
         self.source = source
         self.target = target
-        self.request = request
+        self.ready = ready
         self.data = data
 
     def elaborate(self, platform):
         m = TModule()
 
-        with Transaction().body(m, request=self.request):
+        with Transaction().body(m, ready=self.ready):
             self.target(m, self.data ^ self.source(m).data)
 
         return m

--- a/transactron/core/method.py
+++ b/transactron/core/method.py
@@ -38,9 +38,9 @@ class Method(TransactionBase["Transaction | Method"]):
 
     A `Method` serves to interface a module with external `Transaction`\\s
     or `Method`\\s. It can be called by at most once in a given clock cycle.
-    When a given `Method` is required by multiple `Transaction`\\s
+    When a given `Method` is called by multiple `Transaction`\\s
     (either directly, or indirectly via another `Method`) simultenaously,
-    at most one of them is granted by the `TransactionManager`, and the rest
+    at most one of them is run by the `TransactionManager`, and the rest
     of them must wait. (Non-exclusive methods are an exception to this
     behavior.) Calling a `Method` always takes a single clock cycle.
 

--- a/transactron/lib/adapters.py
+++ b/transactron/lib/adapters.py
@@ -42,10 +42,9 @@ class AdapterTrans(AdapterBase):
     Attributes
     ----------
     en: Signal, in
-        Activates the transaction (sets the `request` signal).
+        Activates the transaction (sets the `ready` signal).
     done: Signal, out
-        Signals that the transaction is performed (returns the `grant`
-        signal).
+        Signals that the transaction is performed (returns the `run` signal).
     data_in: View, in
         Data passed to the `iface` method.
     data_out: View, out
@@ -72,7 +71,7 @@ class AdapterTrans(AdapterBase):
         data_in = Signal.like(self.data_in)
         m.d.comb += data_in.eq(self.data_in)
 
-        with Transaction(name=f"AdapterTrans_{self.iface.name}", src_loc=self.src_loc).body(m, request=self.en):
+        with Transaction(name=f"AdapterTrans_{self.iface.name}", src_loc=self.src_loc).body(m, ready=self.en):
             data_out = self.iface(m, data_in)
             m.d.top_comb += self.data_out.eq(data_out)
             m.d.comb += self.done.eq(1)

--- a/transactron/lib/simultaneous.py
+++ b/transactron/lib/simultaneous.py
@@ -65,11 +65,11 @@ def condition(m: TModule, *, nonblocking: bool = False, priority: bool = False):
         nonlocal last
         if last:
             raise RuntimeError("Condition clause added after catch-all")
-        req = Signal()
-        m.d.top_comb += req.eq(cond if cond is not None else ~Cat(*conds).any())
-        conds.append(req)
+        ready = Signal()
+        m.d.top_comb += ready.eq(cond if cond is not None else ~Cat(*conds).any())
+        conds.append(ready)
         name = f"{this.name}_cond{len(transactions)}"
-        with (transaction := Transaction(name=name, src_loc=src_loc)).body(m, request=req):
+        with (transaction := Transaction(name=name, src_loc=src_loc)).body(m, ready=ready):
             yield
         if transactions and priority:
             transactions[-1].schedule_before(transaction._body)

--- a/transactron/profiler.py
+++ b/transactron/profiler.py
@@ -158,17 +158,17 @@ class TransactionSamples:
 
     Attributes
     ----------
-    request: bool
-        The value of the transaction's ``request`` signal.
+    ready: bool
+        The value of the transaction's ``ready`` signal.
     runnable: bool
         The value of the transaction's ``runnable`` signal.
-    grant: bool
-        The value of the transaction's ``grant`` signal.
+    run: bool
+        The value of the transaction's ``run`` signal.
     """
 
-    request: bool
+    ready: bool
     runnable: bool
-    grant: bool
+    run: bool
 
 
 @dataclass
@@ -227,11 +227,11 @@ class CycleProfile:
         cprof = CycleProfile()
 
         for transaction_id, transaction_samples in samples.transactions.items():
-            if transaction_samples.grant:
+            if transaction_samples.run:
                 cprof.running[transaction_id] = None
-            elif transaction_samples.request and transaction_samples.runnable:
+            elif transaction_samples.ready and transaction_samples.runnable:
                 for transaction2_id in data.transaction_conflicts[transaction_id]:
-                    if samples.transactions[transaction2_id].grant:
+                    if samples.transactions[transaction2_id].run:
                         cprof.locked[transaction_id] = transaction2_id
 
         running = set(cprof.running)

--- a/transactron/testing/profiler.py
+++ b/transactron/testing/profiler.py
@@ -14,7 +14,7 @@ def profiler_process(transaction_manager: TransactionManager, profile: Profile):
         method_map = MethodMap(transaction_manager.transactions)
         profile.transactions_and_methods = profile_data.transactions_and_methods
 
-        transaction_sample_layout = StructLayout({"request": 1, "runnable": 1, "grant": 1})
+        transaction_sample_layout = StructLayout({"ready": 1, "runnable": 1, "run": 1})
 
         async for _, _, *data in (
             sim.tick()
@@ -32,9 +32,9 @@ def profiler_process(transaction_manager: TransactionManager, profile: Profile):
 
             for transaction, tsample in zip(method_map.transactions, transaction_data):
                 samples.transactions[get_id(transaction)] = TransactionSamples(
-                    bool(tsample.request),
+                    bool(tsample.ready),
                     bool(tsample.runnable),
-                    bool(tsample.grant),
+                    bool(tsample.run),
                 )
 
             for method, run in zip(method_map.methods, method_data):

--- a/transactron/utils/gen.py
+++ b/transactron/utils/gen.py
@@ -56,17 +56,17 @@ class TransactionSignalsLocation:
 
     Attributes
     ----------
-    request: list[str]
-        The location of the ``request`` signal.
+    ready: list[str]
+        The location of the ``ready`` signal.
     runnable: list[str]
         The location of the ``runnable`` signal.
-    grant: list[str]
-        The location of the ``grant`` signal.
+    run: list[str]
+        The location of the ``run`` signal.
     """
 
-    request: list[str]
+    ready: list[str]
     runnable: list[str]
-    grant: list[str]
+    run: list[str]
 
 
 @dataclass_json
@@ -193,12 +193,10 @@ def collect_transaction_method_signals(
     get_id = IdGenerator()
 
     for transaction in method_map.transactions:
-        request_loc = get_signal_location(transaction.ready, name_map)
+        ready_loc = get_signal_location(transaction.ready, name_map)
         runnable_loc = get_signal_location(transaction.runnable, name_map)
-        grant_loc = get_signal_location(transaction.run, name_map)
-        transaction_signals_location[get_id(transaction)] = TransactionSignalsLocation(
-            request_loc, runnable_loc, grant_loc
-        )
+        run_loc = get_signal_location(transaction.run, name_map)
+        transaction_signals_location[get_id(transaction)] = TransactionSignalsLocation(ready_loc, runnable_loc, run_loc)
 
     for method in method_map.methods:
         run_loc = get_signal_location(method.run, name_map)


### PR DESCRIPTION
I believe that having distinct names for handshake signals for transactions (`request`/`grant`) and methods (`ready`/run`) is confusing and unneeded:

1. Many docstrings already in the code actually explain the transaction signals using method terminology.
2. In the current implementation, these signals are actually the same under the hood - both transactions and methods are implemented in terms of bodies, and sometimes a transaction body can actually become a method body (simultaneous transactions).
3. Transactions are in practice implemented rarely than methods (in Coreblocks, 60 transactions vs 150 methods), so it's easy to forget the names used in transactions.

Therefore I believe that it's time to change the user-facing names.