### PR TITLE
Rename Scheduler -> OneHotRoundRobin and move test

### DIFF
--- a/test/core/test_transactions.py
+++ b/test/core/test_transactions.py
@@ -53,61 +53,6 @@ class TestNames(TestCase):
             assert m.name == "m"
 
 
-class TestScheduler(TestCaseWithSimulator):
-    def count_test(self, sched, cnt):
-        assert sched.count == cnt
-        assert len(sched.requests) == cnt
-        assert len(sched.grant) == cnt
-        assert len(sched.valid) == 1
-
-    async def sim_step(self, sim, sched: Scheduler, request: int, expected_grant: int):
-        sim.set(sched.requests, request)
-        _, _, valid, grant = await sim.tick().sample(sched.valid, sched.grant)
-
-        if request == 0:
-            assert not valid
-        else:
-            assert grant == expected_grant
-            assert valid
-
-    def test_single(self):
-        sched = Scheduler(1)
-        self.count_test(sched, 1)
-
-        async def process(sim):
-            await self.sim_step(sim, sched, 0, 0)
-            await self.sim_step(sim, sched, 1, 1)
-            await self.sim_step(sim, sched, 1, 1)
-            await self.sim_step(sim, sched, 0, 0)
-
-        with self.run_simulation(sched) as sim:
-            sim.add_testbench(process)
-
-    def test_multi(self):
-        sched = Scheduler(4)
-        self.count_test(sched, 4)
-
-        async def process(sim):
-            await self.sim_step(sim, sched, 0b0000, 0b0000)
-            await self.sim_step(sim, sched, 0b1010, 0b0010)
-            await self.sim_step(sim, sched, 0b1010, 0b1000)
-            await self.sim_step(sim, sched, 0b1010, 0b0010)
-            await self.sim_step(sim, sched, 0b1001, 0b1000)
-            await self.sim_step(sim, sched, 0b1001, 0b0001)
-
-            await self.sim_step(sim, sched, 0b1111, 0b0010)
-            await self.sim_step(sim, sched, 0b1111, 0b0100)
-            await self.sim_step(sim, sched, 0b1111, 0b1000)
-            await self.sim_step(sim, sched, 0b1111, 0b0001)
-
-            await self.sim_step(sim, sched, 0b0000, 0b0000)
-            await self.sim_step(sim, sched, 0b0010, 0b0010)
-            await self.sim_step(sim, sched, 0b0010, 0b0010)
-
-        with self.run_simulation(sched) as sim:
-            sim.add_testbench(process)
-
-
 class TransactionConflictTestCircuit(Elaboratable):
     def __init__(self, scheduler):
         self.scheduler = scheduler

--- a/test/core/test_transactions.py
+++ b/test/core/test_transactions.py
@@ -16,7 +16,6 @@ from transactron.testing import TestCaseWithSimulator, TestbenchIO, data_layout
 
 from transactron import *
 from transactron.lib import Adapter, AdapterTrans
-from transactron.utils import Scheduler
 
 from transactron.core import Priority
 from transactron.core.schedulers import trivial_roundrobin_cc_scheduler, eager_deterministic_cc_scheduler

--- a/test/utils/amaranth_ext/test_elaboratables.py
+++ b/test/utils/amaranth_ext/test_elaboratables.py
@@ -1,7 +1,7 @@
 import pytest
 import random
 
-from transactron.utils import Scheduler, StableSelectingNetwork
+from transactron.utils import OneHotRoundRobin, StableSelectingNetwork
 from transactron.testing import TestCaseWithSimulator, TestbenchContext
 
 
@@ -12,7 +12,7 @@ class TestScheduler(TestCaseWithSimulator):
         assert len(sched.grant) == cnt
         assert len(sched.valid) == 1
 
-    async def sim_step(self, sim, sched: Scheduler, request: int, expected_grant: int):
+    async def sim_step(self, sim, sched: OneHotRoundRobin, request: int, expected_grant: int):
         sim.set(sched.requests, request)
         _, _, valid, grant = await sim.tick().sample(sched.valid, sched.grant)
 
@@ -23,7 +23,7 @@ class TestScheduler(TestCaseWithSimulator):
             assert valid
 
     def test_single(self):
-        sched = Scheduler(1)
+        sched = OneHotRoundRobin(1)
         self.count_test(sched, 1)
 
         async def process(sim):
@@ -36,7 +36,7 @@ class TestScheduler(TestCaseWithSimulator):
             sim.add_testbench(process)
 
     def test_multi(self):
-        sched = Scheduler(4)
+        sched = OneHotRoundRobin(4)
         self.count_test(sched, 4)
 
         async def process(sim):

--- a/test/utils/amaranth_ext/test_elaboratables.py
+++ b/test/utils/amaranth_ext/test_elaboratables.py
@@ -1,8 +1,63 @@
 import pytest
 import random
 
-from transactron.utils import StableSelectingNetwork
+from transactron.utils import Scheduler, StableSelectingNetwork
 from transactron.testing import TestCaseWithSimulator, TestbenchContext
+
+
+class TestScheduler(TestCaseWithSimulator):
+    def count_test(self, sched, cnt):
+        assert sched.count == cnt
+        assert len(sched.requests) == cnt
+        assert len(sched.grant) == cnt
+        assert len(sched.valid) == 1
+
+    async def sim_step(self, sim, sched: Scheduler, request: int, expected_grant: int):
+        sim.set(sched.requests, request)
+        _, _, valid, grant = await sim.tick().sample(sched.valid, sched.grant)
+
+        if request == 0:
+            assert not valid
+        else:
+            assert grant == expected_grant
+            assert valid
+
+    def test_single(self):
+        sched = Scheduler(1)
+        self.count_test(sched, 1)
+
+        async def process(sim):
+            await self.sim_step(sim, sched, 0, 0)
+            await self.sim_step(sim, sched, 1, 1)
+            await self.sim_step(sim, sched, 1, 1)
+            await self.sim_step(sim, sched, 0, 0)
+
+        with self.run_simulation(sched) as sim:
+            sim.add_testbench(process)
+
+    def test_multi(self):
+        sched = Scheduler(4)
+        self.count_test(sched, 4)
+
+        async def process(sim):
+            await self.sim_step(sim, sched, 0b0000, 0b0000)
+            await self.sim_step(sim, sched, 0b1010, 0b0010)
+            await self.sim_step(sim, sched, 0b1010, 0b1000)
+            await self.sim_step(sim, sched, 0b1010, 0b0010)
+            await self.sim_step(sim, sched, 0b1001, 0b1000)
+            await self.sim_step(sim, sched, 0b1001, 0b0001)
+
+            await self.sim_step(sim, sched, 0b1111, 0b0010)
+            await self.sim_step(sim, sched, 0b1111, 0b0100)
+            await self.sim_step(sim, sched, 0b1111, 0b1000)
+            await self.sim_step(sim, sched, 0b1111, 0b0001)
+
+            await self.sim_step(sim, sched, 0b0000, 0b0000)
+            await self.sim_step(sim, sched, 0b0010, 0b0010)
+            await self.sim_step(sim, sched, 0b0010, 0b0010)
+
+        with self.run_simulation(sched) as sim:
+            sim.add_testbench(process)
 
 
 class TestStableSelectingNetwork(TestCaseWithSimulator):

--- a/transactron/core/schedulers.py
+++ b/transactron/core/schedulers.py
@@ -69,9 +69,9 @@ def trivial_roundrobin_cc_scheduler(
         Linear ordering of transactions which is consistent with priority constraints.
     """
     m = Module()
-    sched = Scheduler(len(cc))
-    m.submodules.scheduler = sched
+    rr = OneHotRoundRobin(len(cc))
+    m.submodules.rr = rr
     for k, transaction in enumerate(cc):
-        m.d.comb += sched.requests[k].eq(transaction.ready & transaction.runnable)
-        m.d.comb += transaction.run.eq(sched.grant[k] & sched.valid)
+        m.d.comb += rr.requests[k].eq(transaction.ready & transaction.runnable)
+        m.d.comb += transaction.run.eq(rr.grant[k] & rr.valid)
     return m

--- a/transactron/utils/amaranth_ext/elaboratables.py
+++ b/transactron/utils/amaranth_ext/elaboratables.py
@@ -12,7 +12,7 @@ __all__ = [
     "OneHotSwitchDynamic",
     "OneHotSwitch",
     "ModuleConnector",
-    "Scheduler",
+    "OneHotRoundRobin",
     "RoundRobin",
     "MultiPriorityEncoder",
     "RingMultiPriorityEncoder",
@@ -134,7 +134,7 @@ class ModuleConnector(Elaboratable):
         return m
 
 
-class Scheduler(Elaboratable):
+class OneHotRoundRobin(Elaboratable):
     """Scheduler
 
     An implementation of a round-robin scheduler, which is used in the


### PR DESCRIPTION
This PR moves the test of the awkwardly named `Scheduler` module to the correct place, and changes the awkward name.