### PR TITLE
Rename proxy to provide

### DIFF
--- a/test/test_simultaneous.py
+++ b/test/test_simultaneous.py
@@ -129,8 +129,8 @@ class TransitivityTestCircuit(Elaboratable):
 
         m.submodules.c1 = c1 = Connect([("data", 2)])
         m.submodules.c2 = c2 = Connect([("data", 2)])
-        self.source1.proxy(c1.write)
-        self.source2.proxy(c1.write)
+        self.source1.provide(c1.write)
+        self.source2.provide(c1.write)
         m.submodules.ct = ConnectTrans.create(c2.read, self.target)
         m.submodules.hc1 = HelperConnect(c1.read, c2.write, self.req1, 1)
         m.submodules.hc2 = HelperConnect(c1.read, c2.write, self.req2, 2)

--- a/transactron/core/method.py
+++ b/transactron/core/method.py
@@ -145,18 +145,16 @@ class Method(TransactionBase["Transaction | Method"]):
             raise ValueError(f"Method {value.name} has different interface than {self.name}")
         self._body_ptr = value
 
-    def proxy(self, method: "Method"):
-        """Define as a proxy for another method.
+    def provide(self, method: "Method"):
+        """Provide method definition using another method.
 
-        The calls to this method will be forwarded to `method`.
+        The calls to this method will be forwarded to `method`. Input and
+        output data layouts of this method and `method` must match.
 
         Parameters
         ----------
-        m : TModule
-            Module in which operations on signals should be executed,
-            `proxy` uses the combinational domain only.
         method : Method
-            Method for which this method is a proxy for.
+            Definition of `method` will be provided to this method.
         """
         self._set_impl(method)
 
@@ -345,12 +343,22 @@ class Methods(Sequence[Method]):
     def layout_out(self):
         return self._layout_out
 
-    def proxy(self, methods: Iterable[Method]):
+    def provide(self, methods: Iterable[Method]):
+        """Provide methods' definition using another set of methods.
+
+        The calls to `i`-th method will be forwarded to `i`-th method of
+        `methods` using `Method.provide`.
+
+        Parameters
+        ----------
+        methods : Iterable[Method]
+            Definitions of `methods` will be provided to this method.
+        """
         methods = list(methods)
         if len(methods) != len(self):
             raise ValueError(f"Invalid number of methods: {len(self)} expected, {len(methods)} provided")
         for self_method, method in zip(self, methods):
-            self_method.proxy(method)
+            self_method.provide(method)
 
     def __call__(
         self, m: TModule, arg: Optional[AssignArg] = None, /, enable_call: ValueLike = C(1), **kwargs: AssignArg

--- a/transactron/lib/adapters.py
+++ b/transactron/lib/adapters.py
@@ -90,7 +90,7 @@ class AdapterTrans(AdapterBase):
         """
         src_loc = get_src_loc(src_loc)
         adapter = AdapterTrans(i=method.layout_in, o=method.layout_out, src_loc=src_loc)
-        adapter.iface.proxy(method)
+        adapter.iface.provide(method)
         return adapter
 
     def elaborate(self, platform):
@@ -181,7 +181,7 @@ class Adapter(AdapterBase):
         """
         src_loc = get_src_loc(src_loc)
         adapter = Adapter(i=method.layout_in, o=method.layout_out, src_loc=src_loc, **kwargs)
-        method.proxy(adapter.iface)
+        method.provide(adapter.iface)
         return adapter
 
     def update_args(self, **kwargs: Unpack[AdapterBodyParams]):

--- a/transactron/lib/connectors.py
+++ b/transactron/lib/connectors.py
@@ -316,8 +316,8 @@ class ConnectTrans(Elaboratable):
             Alternatively, the source location to use instead of the default.
         """
         ct = ConnectTrans(method1.layout_in, method1.layout_out, src_loc=get_src_loc(src_loc))
-        ct.method1.proxy(method1)
-        ct.method2.proxy(method2)
+        ct.method1.provide(method1)
+        ct.method2.provide(method2)
         return ct
 
     def elaborate(self, platform):
@@ -408,9 +408,9 @@ class CrossbarConnectTrans(Elaboratable):
             o_layout=methods1[0].layout_out,
         )
         for cct_method1, method1 in zip(cct.methods1, methods1):
-            cct_method1.proxy(method1)
+            cct_method1.provide(method1)
         for cct_method2, method2 in zip(cct.methods2, methods2):
-            cct_method2.proxy(method2)
+            cct_method2.provide(method2)
         return cct
 
     def elaborate(self, platform):

--- a/transactron/lib/reqres.py
+++ b/transactron/lib/reqres.py
@@ -97,7 +97,7 @@ class ArgumentsToResultsZipper(Elaboratable):
             results = forwarder.read(m)
             return {"args": args, "results": results}
 
-        self.peek_arg.proxy(fifo.peek)
+        self.peek_arg.provide(fifo.peek)
 
         return m
 
@@ -183,6 +183,6 @@ class Serializer(Elaboratable):
                 pending_requests.read(m)
                 return self.serialized_resp_method(m)
 
-        self.clear.proxy(pending_requests.clear)
+        self.clear.provide(pending_requests.clear)
 
         return m

--- a/transactron/lib/transformers.py
+++ b/transactron/lib/transformers.py
@@ -137,7 +137,7 @@ class MethodMap(Elaboratable, TransformerOneTarget):
         tr = MethodMap(
             target.layout_in, target.layout_out, i_transform=i_transform, o_transform=o_transform, src_loc=src_loc
         )
-        tr.target.proxy(target)
+        tr.target.provide(target)
         return tr
 
     def elaborate(self, platform):
@@ -233,7 +233,7 @@ class MethodFilter(Elaboratable, TransformerOneTarget):
         tr = MethodFilter(
             target.layout_in, target.layout_out, condition, default, use_condition=use_condition, src_loc=src_loc
         )
-        tr.target.proxy(target)
+        tr.target.provide(target)
         return tr
 
     def elaborate(self, platform):
@@ -329,7 +329,7 @@ class MethodProduct(Elaboratable, Unifier):
             combiner=combiner,
             src_loc=src_loc,
         )
-        tr.targets.proxy(targets)
+        tr.targets.provide(targets)
         return tr
 
     def elaborate(self, platform):
@@ -415,7 +415,7 @@ class MethodTryProduct(Elaboratable, Unifier):
         targets = list(targets)
         src_loc = get_src_loc(src_loc)
         tr = MethodTryProduct(len(targets), targets[0].layout_in, targets[0].layout_out, combiner, src_loc=src_loc)
-        tr.targets.proxy(targets)
+        tr.targets.provide(targets)
         return tr
 
     def elaborate(self, platform):
@@ -472,7 +472,7 @@ class Collector(Elaboratable, Unifier):
         targets = list(targets)
         src_loc = get_src_loc(src_loc)
         tr = Collector(len(targets), targets[0].layout_out)
-        tr.targets.proxy(targets)
+        tr.targets.provide(targets)
         return tr
 
     def elaborate(self, platform):
@@ -481,7 +481,7 @@ class Collector(Elaboratable, Unifier):
         m.submodules.forwarder = forwarder = Forwarder(self.method.layout_out, src_loc=self.src_loc)
         m.submodules.connect = CrossbarConnectTrans.create(self.targets, forwarder.write, src_loc=self.src_loc)
 
-        self.method.proxy(forwarder.read)
+        self.method.provide(forwarder.read)
 
         return m
 
@@ -525,7 +525,7 @@ class NonexclusiveWrapper(Elaboratable, TransformerOneTarget):
         """
         src_loc = get_src_loc(src_loc)
         tr = NonexclusiveWrapper(target.layout_in, target.layout_out)
-        tr.target.proxy(target)
+        tr.target.provide(target)
         return tr
 
     def elaborate(self, platform):


### PR DESCRIPTION
As discussed in #79, `proxy` is now intended to be a mechanism for providing method implementations to components which call external methods. With its new important function, it's time to give it a more descriptive name.