### PR TITLE
Allow Method.provide() outside elaborate

### DIFF
--- a/transactron/core/context.py
+++ b/transactron/core/context.py
@@ -57,13 +57,13 @@ class TransactronContextElaboratable(Elaboratable):
         with silence_mustuse(self.manager.get_dependency(TransactionManagerKey())):
             with self.context():
                 elaboratable = Fragment.get(self.elaboratable, platform)
+                transaction_manager = self.manager.get_dependency(TransactionManagerKey())
+                elab_transaction_manager = Fragment.get(transaction_manager, platform)
 
         m = Module()
 
         m.submodules.main_module = elaboratable
-        m.submodules.transactionManager = self.transaction_manager = self.manager.get_dependency(
-            TransactionManagerKey()
-        )
+        m.submodules.transactionManager = elab_transaction_manager
 
         return m
 

--- a/transactron/core/keys.py
+++ b/transactron/core/keys.py
@@ -4,10 +4,16 @@ from dataclasses import dataclass
 
 if TYPE_CHECKING:
     from .manager import TransactionManager  # noqa: F401 because of https://github.com/PyCQA/pyflakes/issues/571
+    from .method import Method  # noqa: F401 because of https://github.com/PyCQA/pyflakes/issues/571
 
-__all__ = ["TransactionManagerKey"]
+__all__ = ["TransactionManagerKey", "ProvidedMethodsKey"]
 
 
 @dataclass(frozen=True)
 class TransactionManagerKey(SimpleKey["TransactionManager"]):
+    pass
+
+
+@dataclass(frozen=True)
+class ProvidedMethodsKey(ListKey["Method"]):
     pass

--- a/transactron/core/method.py
+++ b/transactron/core/method.py
@@ -12,7 +12,7 @@ from transactron.utils.assign import AssignArg
 from transactron.utils.typing import type_self_add_1pos_kwargs_as
 
 from .body import Body, BodyParams, MBody
-from .keys import TransactionManagerKey
+from .keys import TransactionManagerKey, ProvidedMethodsKey
 from .tmodule import TModule
 from .transaction_base import TransactionBase
 
@@ -157,9 +157,7 @@ class Method(TransactionBase["Transaction | Method"]):
             Definition of `method` will be provided to this method.
         """
         self._set_impl(method)
-
-        manager = DependencyContext.get().get_dependency(TransactionManagerKey())
-        manager._add_proxy_method(self)
+        DependencyContext.get().add_dependency(ProvidedMethodsKey(), self)
 
     @contextmanager
     def body(


### PR DESCRIPTION
Turns out that `Method.provide` is useful to call in constructors, where the transaction manager is currently not accessible. Making it accessible there would probably be useful in other situations, but this would require some rethinking and I don't have a method to do this cleanly. This PR instead removes the need to register methods implemented using `Method.provide`.

Needed for https://github.com/kuznia-rdzeni/coreblocks/pull/834.