### PR TITLE
Collect transactions and methods using keys

### DIFF
--- a/transactron/core/keys.py
+++ b/transactron/core/keys.py
@@ -5,12 +5,23 @@ from dataclasses import dataclass
 if TYPE_CHECKING:
     from .manager import TransactionManager  # noqa: F401 because of https://github.com/PyCQA/pyflakes/issues/571
     from .method import Method  # noqa: F401 because of https://github.com/PyCQA/pyflakes/issues/571
+    from .transaction import Transaction  # noqa: F401 because of https://github.com/PyCQA/pyflakes/issues/571
 
-__all__ = ["TransactionManagerKey", "ProvidedMethodsKey"]
+__all__ = ["TransactionManagerKey", "TransactionsKey", "DefinedMethodsKey", "ProvidedMethodsKey"]
 
 
 @dataclass(frozen=True)
 class TransactionManagerKey(SimpleKey["TransactionManager"]):
+    pass
+
+
+@dataclass(frozen=True)
+class TransactionsKey(ListKey["Transaction"]):
+    pass
+
+
+@dataclass(frozen=True)
+class DefinedMethodsKey(ListKey["Method"]):
     pass
 
 

--- a/transactron/core/method.py
+++ b/transactron/core/method.py
@@ -12,7 +12,7 @@ from transactron.utils.assign import AssignArg
 from transactron.utils.typing import type_self_add_1pos_kwargs_as
 
 from .body import Body, BodyParams, MBody
-from .keys import TransactionManagerKey, ProvidedMethodsKey
+from .keys import DefinedMethodsKey, ProvidedMethodsKey
 from .tmodule import TModule
 from .transaction_base import TransactionBase
 
@@ -235,8 +235,7 @@ class Method(TransactionBase["Transaction | Method"]):
             with m.AvoidedIf(body.run):
                 yield body.data_in
 
-        manager = DependencyContext.get().get_dependency(TransactionManagerKey())
-        manager._add_method(self)
+        DependencyContext.get().add_dependency(DefinedMethodsKey(), self)
 
     def __call__(
         self, m: TModule, arg: Optional[AssignArg] = None, /, enable_call: ValueLike = C(1), **kwargs: AssignArg

--- a/transactron/core/transaction.py
+++ b/transactron/core/transaction.py
@@ -10,6 +10,7 @@ from transactron.utils.transactron_helpers import get_caller_class_name, get_src
 from .keys import *
 from contextlib import contextmanager
 from .body import Body, TBody
+from .keys import TransactionsKey
 from .tmodule import TModule
 from .transaction_base import TransactionBase
 
@@ -76,8 +77,7 @@ class Transaction(TransactionBase["Transaction | Method"]):
         super().__init__(src_loc=get_src_loc(src_loc))
         self.owner, owner_name = get_caller_class_name(default="$transaction")
         self.name = name or tracer.get_var_name(depth=2, default=owner_name)
-        manager = DependencyContext.get().get_dependency(TransactionManagerKey())
-        manager._add_transaction(self)
+        DependencyContext.get().add_dependency(TransactionsKey(), self)
         self.ready = Signal(name=self.owned_name + "_ready")
         self.runnable = Signal(name=self.owned_name + "_runnable")
         self.run = Signal(name=self.owned_name + "_run")


### PR DESCRIPTION
Transactions and methods are collected using `ListKeys` instead of using `TransactionManager` attributes. In consequence, transactions can now be declared outside `elaborate`.