### PR TITLE
Heterogenous product transformers

### DIFF
--- a/test/lib/test_transformers.py
+++ b/test/lib/test_transformers.py
@@ -145,7 +145,7 @@ class TestMethodProduct(TestCaseWithSimulator):
         if add_combiner:
             combiner = (layout, lambda _, vs: {"data": sum(x.data for x in vs)})
 
-        m = SimpleTestCircuit(MethodProduct(targets, layout, layout, combiner))
+        m = SimpleTestCircuit(MethodProduct(layout, (layout,) * targets, combiner))
 
         method_en = [False] * targets
 
@@ -194,7 +194,7 @@ class TestMethodTryProduct(TestCaseWithSimulator):
         if add_combiner:
             combiner = (layout, lambda _, vs: {"data": sum(Mux(s, r, 0) for (s, r) in vs)})
 
-        m = SimpleTestCircuit(MethodTryProduct(targets, layout, layout, combiner))
+        m = SimpleTestCircuit(MethodTryProduct(layout, (layout,) * targets, combiner))
 
         method_en = [False] * targets
 


### PR DESCRIPTION
PR #79 silently started requiring the output layouts of methods used in `MethodProduct` to be the same. It's useful and natural to not require this, so this PR reverses that.