### PR TITLE
Pysim performance workaround

### DIFF
--- a/transactron/core/manager.py
+++ b/transactron/core/manager.py
@@ -344,8 +344,10 @@ class TransactionManager(Elaboratable):
         for elem in method_map.methods_and_transactions:
             elem._set_method_uses(m)
 
+        # Signals assigned here because `method.provide` sometimes needs to be used without a TModule.
+        # Unfortunately, assignments across modules seem to cause a performance hit in pysim.
         provided_methods = DependencyContext.get().get_dependency(ProvidedMethodsKey())
-        for method in chain(self.methods, provided_methods):
+        for method in chain(provided_methods):
             m.d.comb += method.ready.eq(method._body.ready)
             m.d.comb += method.run.eq(method._body.run)
             m.d.comb += method.data_in.eq(method._body.data_in)

--- a/transactron/core/method.py
+++ b/transactron/core/method.py
@@ -235,6 +235,14 @@ class Method(TransactionBase["Transaction | Method"]):
             with m.AvoidedIf(body.run):
                 yield body.data_in
 
+        # Assigned here instead of the transaction manager because:
+        # - The waveforms will be available in the module which defined the method.
+        # - This simulates faster in pysim.
+        m.d.comb += self.ready.eq(body.ready)
+        m.d.comb += self.run.eq(body.run)
+        m.d.comb += self.data_in.eq(body.data_in)
+        m.d.comb += self.data_out.eq(body.data_out)
+
         DependencyContext.get().add_dependency(DefinedMethodsKey(), self)
 
     def __call__(


### PR DESCRIPTION
There is a performance issue in Amaranth's pysim which causes slowdowns dependent on the module in which the signal is assigned. This PR is intended to work around the issue. It should still be fixed in Amaranth IMHO - because of how Transactron is constructed, a fix will probably speed up Coreblocks tests quite a lot.