### PR TITLE
Add exclude parameter to SimpleTestCircuit

### DIFF
--- a/test/testing/test_method_mock.py
+++ b/test/testing/test_method_mock.py
@@ -63,6 +63,14 @@ class TestMethodMock(TestCaseWithSimulator):
         with self.run_simulation(self.dut) as sim:
             sim.add_testbench(self.process)
 
+    def test_method_mock_exclude(self, test_circuit):
+        self.dut = SimpleTestCircuit(test_circuit(1), exclude={"wrapper"})
+
+        assert not hasattr(self.dut, "wrapper")
+
+        with self.run_simulation(self.dut):
+            pass
+
 
 class ReverseMethodMockTestCircuit(Elaboratable):
     def __init__(self, width):

--- a/transactron/testing/test_circuit.py
+++ b/transactron/testing/test_circuit.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterable
 import inspect
 from typing import TypeVar, Generic, TypeGuard, Any, TypeAlias
 from amaranth import *
@@ -34,9 +35,10 @@ _T_HasElaborate = TypeVar("_T_HasElaborate", bound=HasElaborate)
 
 
 class SimpleTestCircuit(Elaboratable, Generic[_T_HasElaborate]):
-    def __init__(self, dut: _T_HasElaborate):
+    def __init__(self, dut: _T_HasElaborate, *, exclude: Iterable[str] = ()):
         self._dut = dut
         self._io: dict[str, _T_nested_collection[TestbenchIO]] = {}
+        self._exclude = set(exclude)
 
     def __getattr__(self, name: str) -> Any:
         try:
@@ -83,6 +85,8 @@ class SimpleTestCircuit(Elaboratable, Generic[_T_HasElaborate]):
             hints.update(inspect.get_annotations(cls, eval_str=True))
 
         for name, attr in vars(self._dut).items():
+            if name in self._exclude:
+                continue
             if guard_nested_collection(attr, Method, Methods) and attr:
                 if (
                     name in hints


### PR DESCRIPTION
This allows to exclude some attributes when creating a `SimpleTestCircuit`.