### PR TITLE
add traceback when calling a single method in the same transaction

### DIFF
--- a/test/core/test_methods.py
+++ b/test/core/test_methods.py
@@ -1,16 +1,18 @@
-import random
 from collections.abc import Callable, Sequence
-from unittest import TestCase
-
 import pytest
+import random
 from amaranth import *
-from amaranth.lib.data import StructLayout
 from amaranth.sim import *
+from amaranth.lib.data import StructLayout
+
+from transactron.testing import TestCaseWithSimulator, TestbenchIO, data_layout, SimpleTestCircuit
 
 from transactron import *
-from transactron.lib import *
-from transactron.testing import SimpleTestCircuit, TestbenchIO, TestCaseWithSimulator, data_layout
 from transactron.utils import MethodStruct
+from transactron.lib import *
+
+from unittest import TestCase
+
 from transactron.utils.assign import AssignArg
 
 
@@ -199,7 +201,6 @@ class TestInvalidMethods(TestCase):
 
                 return m
 
-        Fragment.get(TransactronContextElaboratable(Twice()), platform=None)
         self.assert_re("called twice", Twice())
 
     def test_twice_cond(self):
@@ -252,7 +253,6 @@ class TestInvalidMethods(TestCase):
                 return m
 
         m = Diamond()
-        Fragment.get(TransactronContextElaboratable(AdapterCircuit(m, [m.meth4])), platform=None)
         self.assert_re("called twice", AdapterCircuit(m, [m.meth4]))
 
     def test_loop(self):
@@ -269,7 +269,6 @@ class TestInvalidMethods(TestCase):
                 return m
 
         m = Loop()
-        Fragment.get(TransactronContextElaboratable(AdapterCircuit(m, [m.meth1])), platform=None)
         self.assert_re("called twice", AdapterCircuit(m, [m.meth1]))
 
     def test_cycle(self):
@@ -290,7 +289,6 @@ class TestInvalidMethods(TestCase):
                 return m
 
         m = Cycle()
-        Fragment.get(TransactronContextElaboratable(AdapterCircuit(m, [m.meth1])), platform=None)
         self.assert_re("called twice", AdapterCircuit(m, [m.meth1]))
 
     def test_redefine(self):

--- a/test/core/test_methods.py
+++ b/test/core/test_methods.py
@@ -1,18 +1,16 @@
-from collections.abc import Callable, Sequence
-import pytest
 import random
-from amaranth import *
-from amaranth.sim import *
-from amaranth.lib.data import StructLayout
-
-from transactron.testing import TestCaseWithSimulator, TestbenchIO, data_layout, SimpleTestCircuit
-
-from transactron import *
-from transactron.utils import MethodStruct
-from transactron.lib import *
-
+from collections.abc import Callable, Sequence
 from unittest import TestCase
 
+import pytest
+from amaranth import *
+from amaranth.lib.data import StructLayout
+from amaranth.sim import *
+
+from transactron import *
+from transactron.lib import *
+from transactron.testing import SimpleTestCircuit, TestbenchIO, TestCaseWithSimulator, data_layout
+from transactron.utils import MethodStruct
 from transactron.utils.assign import AssignArg
 
 
@@ -201,6 +199,7 @@ class TestInvalidMethods(TestCase):
 
                 return m
 
+        Fragment.get(TransactronContextElaboratable(Twice()), platform=None)
         self.assert_re("called twice", Twice())
 
     def test_twice_cond(self):
@@ -253,6 +252,7 @@ class TestInvalidMethods(TestCase):
                 return m
 
         m = Diamond()
+        Fragment.get(TransactronContextElaboratable(AdapterCircuit(m, [m.meth4])), platform=None)
         self.assert_re("called twice", AdapterCircuit(m, [m.meth4]))
 
     def test_loop(self):
@@ -269,6 +269,7 @@ class TestInvalidMethods(TestCase):
                 return m
 
         m = Loop()
+        Fragment.get(TransactronContextElaboratable(AdapterCircuit(m, [m.meth1])), platform=None)
         self.assert_re("called twice", AdapterCircuit(m, [m.meth1]))
 
     def test_cycle(self):
@@ -289,6 +290,7 @@ class TestInvalidMethods(TestCase):
                 return m
 
         m = Cycle()
+        Fragment.get(TransactronContextElaboratable(AdapterCircuit(m, [m.meth1])), platform=None)
         self.assert_re("called twice", AdapterCircuit(m, [m.meth1]))
 
     def test_redefine(self):

--- a/transactron/core/manager.py
+++ b/transactron/core/manager.py
@@ -1,6 +1,6 @@
 from collections import defaultdict, deque
 from collections.abc import Callable, Iterable, Sequence, Collection, Mapping
-from typing import Optional, TypeAlias
+from typing import TypeAlias
 from os import environ
 from amaranth import *
 from itertools import chain, filterfalse, product
@@ -36,94 +36,47 @@ class MethodMap:
         self.ancestors_by_call = dict[tuple[TBody, MBody], tuple[MBody, ...]]()
         self.method_parents = defaultdict[MBody, list[Body]](list)
 
-        methods_by_transaction_internal = dict[TBody, dict[MBody, Body]]()
+        def loc_str(body: Body) -> str:
+            return f"{body.src_loc[0]}:{body.src_loc[1]}"
 
-        def get_depth(transaction: TBody, method_call: Body) -> int:
-            depth = 0
-            current = method_call
-            while current is not transaction:
-                depth += 1
-                current = methods_by_transaction_internal[transaction][MBody(current)]
-            return depth
+        def path_str(path: Sequence[MBody]) -> str:
+            return " -> ".join(f"{method.name} ({loc_str(method)})" for method in path)
 
-        def find_call_paths_from_tree(transaction: TBody, m1: Body, m2: Body) -> tuple[list[Body], list[Body]]:
-            depth1 = get_depth(transaction, m1)
-            depth2 = get_depth(transaction, m2)
-
-            path1 = []
-            path2 = []
-
-            while depth1 > depth2:
-                path1.append(m1)
-                m1 = methods_by_transaction_internal[transaction][MBody(m1)]
-                depth1 -= 1
-
-            while depth2 > depth1:
-                path2.append(m2)
-                m2 = methods_by_transaction_internal[transaction][MBody(m2)]
-                depth2 -= 1
-
-            while m1 != m2:
-                path1.append(m1)
-                path2.append(m2)
-                m1 = methods_by_transaction_internal[transaction][MBody(m1)]
-                m2 = methods_by_transaction_internal[transaction][MBody(m2)]
-
-            # append the common ancestor
-            path1.append(m1)
-            path2.append(m2)
-
-            return path1, path2
-
-        def check_is_cycle(transaction: TBody, current: Body, parent: Body) -> Optional[list[Body]]:
-            cycle = [parent]
-
-            while current is not transaction and current != parent:
-                cycle.append(current)
-                current = methods_by_transaction_internal[transaction][MBody(current)]
-
-            return cycle if current == parent else None
-
-        def report_bad_case(transaction: TBody, source: Body, method: MBody):
+        def report_bad_case(transaction: TBody, method: MBody, second_ancestors: tuple[MBody, ...]):
+            first_ancestors = self.ancestors_by_call[(transaction, method)]
             msg = (
-                f"Method '{method.name}' ({method.src_loc}) called twice from "
-                + f"transaction '{transaction.name}' ({transaction.src_loc})"
+                f"Method '{method.name}' ({loc_str(method)}) called twice from "
+                + f"transaction '{transaction.name}' ({loc_str(transaction)})"
             )
 
-            cycle = check_is_cycle(transaction, source, method)
-            if cycle is not None:
-                cycle = cycle + [method]
-                cycle_str = " -> ".join(f"{m.name} ({m.src_loc})" for m in reversed(cycle))
-                msg += f"\nCycle: {cycle_str}"
+            if method in second_ancestors[1:]:
+                cycle_start = second_ancestors[1:].index(method) + 1
+                cycle = second_ancestors[cycle_start::-1] + (method,)
+                msg += f"\nCycle: {path_str(cycle)}"
             else:
-                path1, path2 = find_call_paths_from_tree(transaction, source, method)
-                path1 = [method] + path1
+                first_path = tuple(reversed(first_ancestors))
+                second_path = tuple(reversed(second_ancestors))
 
-                path1_str = " -> ".join(f"{m.name} ({m.src_loc})" for m in reversed(path1))
-                path2_str = " -> ".join(f"{m.name} ({m.src_loc})" for m in reversed(path2))
-
-                msg += f"\nFirst call path: {path1_str}"
-                msg += f"\nSecond call path: {path2_str}"
+                msg += f"\nFirst call path: {path_str(first_path)}"
+                msg += f"\nSecond call path: {path_str(second_path)}"
 
             raise RuntimeError(msg)
 
         def rec(transaction: TBody, source: Body, ancestors: tuple[MBody, ...]):
             for method_obj, (arg_rec, _) in source.method_uses.items():
                 method = MBody(method_obj._body)
-                if method in methods_by_transaction_internal[transaction]:
-                    report_bad_case(transaction, source, method)
-                methods_by_transaction_internal[transaction][method] = source
+                new_ancestors = (method, *ancestors)
+                if method in self.methods_by_transaction[transaction]:
+                    report_bad_case(transaction, method, new_ancestors)
+                self.methods_by_transaction[transaction].append(method)
                 self.transactions_by_method[method].append(transaction)
                 self.argument_by_call[(transaction, method)] = arg_rec
-                self.ancestors_by_call[(transaction, method)] = new_ancestors = (method, *ancestors)
+                self.ancestors_by_call[(transaction, method)] = new_ancestors
                 rec(transaction, method, new_ancestors)
 
         for transaction in transactions:
-            methods_by_transaction_internal[TBody(transaction._body)] = dict()
+            self.methods_by_transaction[TBody(transaction._body)] = []
             rec(TBody(transaction._body), transaction._body, ())
-            self.methods_by_transaction = {
-                transaction: list(methods.keys()) for transaction, methods in methods_by_transaction_internal.items()
-            }
 
         for transaction_or_method in self.methods_and_transactions:
             for method in transaction_or_method.method_uses.keys():

--- a/transactron/core/manager.py
+++ b/transactron/core/manager.py
@@ -79,10 +79,9 @@ class MethodMap:
             return path1, path2
 
         def check_is_cycle(transaction: TBody, current: Body, parent: Body) -> Optional[list[Body]]:
-
             cycle = [parent]
             if current == parent:
-                return []
+                return cycle
 
             while current is not transaction:
                 cycle.append(current)

--- a/transactron/core/manager.py
+++ b/transactron/core/manager.py
@@ -50,7 +50,7 @@ class MethodMap:
             depth1 = get_depth(transaction, m1)
             depth2 = get_depth(transaction, m2)
 
-            path1 = []
+            path1 = [m2]
             path2 = []
 
             current1 = m1
@@ -58,20 +58,17 @@ class MethodMap:
 
             while depth1 > depth2:
                 path1.append(current1)
-                print(f"1: skipping {current1.name}")
                 current1 = methods_by_transaction_internal[transaction][MBody(current1)]
                 depth1 -= 1
 
             while depth2 > depth1:
                 path2.append(current2)
-                print(f"2: skipping {current2.name}")
                 current2 = methods_by_transaction_internal[transaction][MBody(current2)]
                 depth2 -= 1
 
             while current1 != current2:
                 path1.append(current1)
                 path2.append(current2)
-                print(f"3: skipping {current1.name} and {current2.name}")
                 current1 = methods_by_transaction_internal[transaction][MBody(current1)]
                 current2 = methods_by_transaction_internal[transaction][MBody(current2)]
 
@@ -82,8 +79,11 @@ class MethodMap:
             return path1, path2
 
         def check_is_cycle(transaction: TBody, current: Body, parent: Body) -> Optional[list[Body]]:
-            print(f"Checking for cycle: current={current.name}, parent={parent.name}")
-            cycle = []
+
+            cycle = [parent]
+            if current == parent:
+                return []
+
             while current is not transaction:
                 cycle.append(current)
                 current = methods_by_transaction_internal[transaction][MBody(current)]
@@ -97,16 +97,13 @@ class MethodMap:
                 + f"transaction '{transaction.name}' ({transaction.src_loc})"
             )
 
-            if source is method:
-                msg += " (self call)"
-            elif cycle := check_is_cycle(transaction, source, method):
-                cycle = [method] + cycle + [method]
+            cycle = check_is_cycle(transaction, source, method)
+            if cycle is not None:
+                cycle = cycle + [method]
                 cycle_str = " -> ".join(f"{m.name} ({m.src_loc})" for m in reversed(cycle))
                 msg += f"\nCycle: {cycle_str}"
             else:
                 path1, path2 = find_call_paths_from_tree(transaction, source, method)
-                path1 = [method] + path1
-                path2 = [method] + path2
 
                 path1_str = " -> ".join(f"{m.name} ({m.src_loc})" for m in reversed(path1))
                 path2_str = " -> ".join(f"{m.name} ({m.src_loc})" for m in reversed(path2))

--- a/transactron/core/manager.py
+++ b/transactron/core/manager.py
@@ -80,15 +80,12 @@ class MethodMap:
 
         def check_is_cycle(transaction: TBody, current: Body, parent: Body) -> Optional[list[Body]]:
             cycle = [parent]
-            if current == parent:
-                return cycle
 
-            while current is not transaction:
+            while current is not transaction and current != parent:
                 cycle.append(current)
                 current = methods_by_transaction_internal[transaction][MBody(current)]
-                if current == parent:
-                    return cycle
-            return None
+
+            return cycle if current == parent else None
 
         def report_bad_case(transaction: TBody, source: Body, method: MBody):
             msg = (

--- a/transactron/core/manager.py
+++ b/transactron/core/manager.py
@@ -1,6 +1,6 @@
 from collections import defaultdict, deque
 from collections.abc import Callable, Iterable, Sequence, Collection, Mapping
-from typing import TypeAlias
+from typing import Optional, TypeAlias
 from os import environ
 from amaranth import *
 from itertools import chain, filterfalse, product
@@ -36,20 +36,103 @@ class MethodMap:
         self.ancestors_by_call = dict[tuple[TBody, MBody], tuple[MBody, ...]]()
         self.method_parents = defaultdict[MBody, list[Body]](list)
 
+        methods_by_transaction_internal = dict[TBody, dict[MBody, Body]]()
+
+        def get_depth(transaction: TBody, method_call: Body) -> int:
+            depth = 0
+            current = method_call
+            while current is not transaction:
+                depth += 1
+                current = methods_by_transaction_internal[transaction][MBody(current)]
+            return depth
+
+        def find_call_paths_from_tree(transaction: TBody, m1: Body, m2: Body) -> tuple[list[Body], list[Body]]:
+            depth1 = get_depth(transaction, m1)
+            depth2 = get_depth(transaction, m2)
+
+            path1 = []
+            path2 = []
+
+            current1 = m1
+            current2 = m2
+
+            while depth1 > depth2:
+                path1.append(current1)
+                print(f"1: skipping {current1.name}")
+                current1 = methods_by_transaction_internal[transaction][MBody(current1)]
+                depth1 -= 1
+
+            while depth2 > depth1:
+                path2.append(current2)
+                print(f"2: skipping {current2.name}")
+                current2 = methods_by_transaction_internal[transaction][MBody(current2)]
+                depth2 -= 1
+
+            while current1 != current2:
+                path1.append(current1)
+                path2.append(current2)
+                print(f"3: skipping {current1.name} and {current2.name}")
+                current1 = methods_by_transaction_internal[transaction][MBody(current1)]
+                current2 = methods_by_transaction_internal[transaction][MBody(current2)]
+
+            # append the common ancestor
+            path1.append(current1)
+            path2.append(current2)
+
+            return path1, path2
+
+        def check_is_cycle(transaction: TBody, current: Body, parent: Body) -> Optional[list[Body]]:
+            print(f"Checking for cycle: current={current.name}, parent={parent.name}")
+            cycle = []
+            while current is not transaction:
+                cycle.append(current)
+                current = methods_by_transaction_internal[transaction][MBody(current)]
+                if current == parent:
+                    return cycle
+            return None
+
+        def report_bad_case(transaction: TBody, source: Body, method: MBody):
+            msg = (
+                f"Method '{method.name}' ({method.src_loc}) called twice from "
+                + f"transaction '{transaction.name}' ({transaction.src_loc})"
+            )
+
+            if source is method:
+                msg += " (self call)"
+            elif cycle := check_is_cycle(transaction, source, method):
+                cycle = [method] + cycle + [method]
+                cycle_str = " -> ".join(f"{m.name} ({m.src_loc})" for m in reversed(cycle))
+                msg += f"\nCycle: {cycle_str}"
+            else:
+                path1, path2 = find_call_paths_from_tree(transaction, source, method)
+                path1 = [method] + path1
+                path2 = [method] + path2
+
+                path1_str = " -> ".join(f"{m.name} ({m.src_loc})" for m in reversed(path1))
+                path2_str = " -> ".join(f"{m.name} ({m.src_loc})" for m in reversed(path2))
+
+                msg += f"\nFirst call path: {path1_str}"
+                msg += f"\nSecond call path: {path2_str}"
+
+            raise RuntimeError(msg)
+
         def rec(transaction: TBody, source: Body, ancestors: tuple[MBody, ...]):
             for method_obj, (arg_rec, _) in source.method_uses.items():
                 method = MBody(method_obj._body)
-                if method in self.methods_by_transaction[transaction]:
-                    raise RuntimeError(f"Method '{method_obj.name}' can't be called twice from the same transaction")
-                self.methods_by_transaction[transaction].append(method)
+                if method in methods_by_transaction_internal[transaction]:
+                    report_bad_case(transaction, source, method)
+                methods_by_transaction_internal[transaction][method] = source
                 self.transactions_by_method[method].append(transaction)
                 self.argument_by_call[(transaction, method)] = arg_rec
                 self.ancestors_by_call[(transaction, method)] = new_ancestors = (method, *ancestors)
                 rec(transaction, method, new_ancestors)
 
         for transaction in transactions:
-            self.methods_by_transaction[TBody(transaction._body)] = []
+            methods_by_transaction_internal[TBody(transaction._body)] = dict()
             rec(TBody(transaction._body), transaction._body, ())
+            self.methods_by_transaction = {
+                transaction: list(methods.keys()) for transaction, methods in methods_by_transaction_internal.items()
+            }
 
         for transaction_or_method in self.methods_and_transactions:
             for method in transaction_or_method.method_uses.keys():

--- a/transactron/core/manager.py
+++ b/transactron/core/manager.py
@@ -50,31 +50,28 @@ class MethodMap:
             depth1 = get_depth(transaction, m1)
             depth2 = get_depth(transaction, m2)
 
-            path1 = [m2]
+            path1 = []
             path2 = []
 
-            current1 = m1
-            current2 = m2
-
             while depth1 > depth2:
-                path1.append(current1)
-                current1 = methods_by_transaction_internal[transaction][MBody(current1)]
+                path1.append(m1)
+                m1 = methods_by_transaction_internal[transaction][MBody(m1)]
                 depth1 -= 1
 
             while depth2 > depth1:
-                path2.append(current2)
-                current2 = methods_by_transaction_internal[transaction][MBody(current2)]
+                path2.append(m2)
+                m2 = methods_by_transaction_internal[transaction][MBody(m2)]
                 depth2 -= 1
 
-            while current1 != current2:
-                path1.append(current1)
-                path2.append(current2)
-                current1 = methods_by_transaction_internal[transaction][MBody(current1)]
-                current2 = methods_by_transaction_internal[transaction][MBody(current2)]
+            while m1 != m2:
+                path1.append(m1)
+                path2.append(m2)
+                m1 = methods_by_transaction_internal[transaction][MBody(m1)]
+                m2 = methods_by_transaction_internal[transaction][MBody(m2)]
 
             # append the common ancestor
-            path1.append(current1)
-            path2.append(current2)
+            path1.append(m1)
+            path2.append(m2)
 
             return path1, path2
 
@@ -100,6 +97,7 @@ class MethodMap:
                 msg += f"\nCycle: {cycle_str}"
             else:
                 path1, path2 = find_call_paths_from_tree(transaction, source, method)
+                path1 = [method] + path1
 
                 path1_str = " -> ".join(f"{m.name} ({m.src_loc})" for m in reversed(path1))
                 path2_str = " -> ".join(f"{m.name} ({m.src_loc})" for m in reversed(path2))

--- a/transactron/core/manager.py
+++ b/transactron/core/manager.py
@@ -36,22 +36,19 @@ class MethodMap:
         self.ancestors_by_call = dict[tuple[TBody, MBody], tuple[MBody, ...]]()
         self.method_parents = defaultdict[MBody, list[Body]](list)
 
-        def loc_str(body: Body) -> str:
-            return f"{body.src_loc[0]}:{body.src_loc[1]}"
-
         def path_str(path: Sequence[MBody]) -> str:
-            return " -> ".join(f"{method.name} ({loc_str(method)})" for method in path)
+            return " -> ".join(f"{method.name} {method.src_loc}" for method in path)
 
         def report_bad_case(transaction: TBody, method: MBody, second_ancestors: tuple[MBody, ...]):
             first_ancestors = self.ancestors_by_call[(transaction, method)]
             msg = (
-                f"Method '{method.name}' ({loc_str(method)}) called twice from "
-                + f"transaction '{transaction.name}' ({loc_str(transaction)})"
+                f"Method '{method.name}' {method.src_loc} called twice from "
+                + f"transaction '{transaction.name}' {transaction.src_loc}"
             )
 
             if method in second_ancestors[1:]:
                 cycle_start = second_ancestors[1:].index(method) + 1
-                cycle = second_ancestors[cycle_start::-1] + (method,)
+                cycle = second_ancestors[cycle_start::-1]
                 msg += f"\nCycle: {path_str(cycle)}"
             else:
                 first_path = tuple(reversed(first_ancestors))


### PR DESCRIPTION
This PR adds traceback when a method is called two times from the same transaction. It detects cycles and two call trees with a common ancestor.

Was tested on test/core/test_methods.py