### PR TITLE
Fix flaky TestContentAddressableMemory

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - 'feature/**'
-      - 'lekcyjna123/20260406-flaky-CAM'
   pull_request:
     branches:
       - master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
           pip3 install .[dev]
 
       - name: Run tests
-        run: pytest --verbose -n auto --transactron-traces --transactron-profile
+        run: pytest --verbose -n auto --transactron-traces --transactron-profile --durations 0
 
   lint:
     name: Check code formatting and typing

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - 'feature/**'
+      - 'lekcyjna123/20260406-flaky-CAM'
   pull_request:
     branches:
       - master

--- a/test/lib/test_storage.py
+++ b/test/lib/test_storage.py
@@ -122,7 +122,7 @@ class TestContentAddressableMemory(TestCaseWithSimulator):
         max_examples=10,
         phases=(Phase.explicit, Phase.reuse, Phase.generate, Phase.shrink),
         derandomize=True,
-        deadline=timedelta(milliseconds=500),
+        deadline=timedelta(milliseconds=2000),
     )
     @given(
         generate_process_input(test_number, nop_number, [("addr", addr_layout), ("data", content_layout)]),


### PR DESCRIPTION
Here is an extension of timeout for TestContentAddressableMemory. For the justification see: #130
I have also added printing of execution times so that further similar problems will have more data to operate.