### PR TITLE
Public transaction signals in top_comb

### DIFF
--- a/transactron/core/method.py
+++ b/transactron/core/method.py
@@ -249,10 +249,10 @@ class Method(TransactionBase["Transaction | Method"]):
         # Assigned here instead of the transaction manager because:
         # - The waveforms will be available in the module which defined the method.
         # - This simulates faster in pysim.
-        m.d.comb += self.ready.eq(body.ready)
-        m.d.comb += self.run.eq(body.run)
-        m.d.comb += self.data_in.eq(body.data_in)
-        m.d.comb += self.data_out.eq(body.data_out)
+        m.d.top_comb += self.ready.eq(body.ready)
+        m.d.top_comb += self.run.eq(body.run)
+        m.d.top_comb += self.data_in.eq(body.data_in)
+        m.d.top_comb += self.data_out.eq(body.data_out)
 
         DependencyContext.get().add_dependency(DefinedMethodsKey(), self)
 

--- a/transactron/core/transaction.py
+++ b/transactron/core/transaction.py
@@ -94,9 +94,9 @@ class Transaction(TransactionBase["Transaction | Method"]):
         if value.data_in.shape().size != 0 or value.data_out.shape().size != 0:
             raise ValueError(f"Transaction body {value.name} has invalid interface")
         self._body_ptr = value
-        m.d.comb += self.ready.eq(value.ready)
-        m.d.comb += self.runnable.eq(value.runnable)
-        m.d.comb += self.run.eq(value.run)
+        m.d.top_comb += self.ready.eq(value.ready)
+        m.d.top_comb += self.runnable.eq(value.runnable)
+        m.d.top_comb += self.run.eq(value.run)
 
     @contextmanager
     def body(self, m: TModule, *, ready: ValueLike = C(1)) -> Iterator["Transaction"]:


### PR DESCRIPTION
This change makes public-facing transaction signals always equal to the values generated from the transaction manager, as originally intended. Noticed in #132.