### PR TITLE
Switch to Python 3.13

### DIFF
--- a/.github/workflows/deploy_gh_pages.yml
+++ b/.github/workflows/deploy_gh_pages.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.13"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.13'
           cache: 'pip'
           cache-dependency-path: |
             pyproject.toml
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.13'
           cache: 'pip'
           cache-dependency-path: |
             pyproject.toml

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.13'
     - name: Omit local version for Test PyPI upload
       if: github.event_name == 'push' && github.ref == 'refs/heads/master'
       run: echo SETUPTOOLS_SCM_OVERRIDES_FOR_TRANSACTRON='{local_scheme="no-local-version"}' >> $GITHUB_ENV

--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -4,7 +4,7 @@
 
 In order to prepare the development environment, please follow the steps below:
 
-1. Install the Python 3.11 interpreter and pip package manager.
+1. Install the Python 3.13 interpreter and pip package manager.
     * Optionally create a Python virtual environment with `python3 -m venv venv` in the project directory and activate it using generated script: `. venv/bin/activate`.
 2. Install all required libraries with `pip3 install .[dev]`.
 4. Optionally, install all precommit hooks with `pre-commit install`. This will automatically run the linter before commits.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "tabulate ~= 0.9.0",
     "networkx ~= 3.4.2"
 ]
-requires-python = ">=3.11"
+requires-python = ">=3.13"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",

--- a/transactron/core/method.py
+++ b/transactron/core/method.py
@@ -6,7 +6,7 @@ from transactron.utils import *
 from amaranth import *
 from amaranth import tracer
 from amaranth_types import ValueLike
-from typing import TYPE_CHECKING, Annotated, Optional, Iterator, TypeAlias, TypeVar, Unpack, overload
+from typing import TYPE_CHECKING, Annotated, Optional, Iterator, Unpack, overload
 from .transaction_base import *
 from contextlib import contextmanager
 from transactron.utils.assign import AssignArg
@@ -30,9 +30,8 @@ class MethodDir(enum.Enum):
     REQUIRED = enum.auto()
 
 
-_T = TypeVar("_T")
-Provided: TypeAlias = Annotated[_T, MethodDir.PROVIDED]
-Required: TypeAlias = Annotated[_T, MethodDir.REQUIRED]
+type Provided[T] = Annotated[T, MethodDir.PROVIDED]
+type Required[T] = Annotated[T, MethodDir.REQUIRED]
 
 
 class Method(TransactionBase["Transaction | Method"]):

--- a/transactron/core/method.py
+++ b/transactron/core/method.py
@@ -6,7 +6,7 @@ from transactron.utils import *
 from amaranth import *
 from amaranth import tracer
 from amaranth_types import ValueLike
-from typing import TYPE_CHECKING, Annotated, Optional, Iterator, Unpack, overload
+from typing import TYPE_CHECKING, Annotated, Optional, Iterator, TypeAlias, TypeVar, Unpack, overload
 from .transaction_base import *
 from contextlib import contextmanager
 from transactron.utils.assign import AssignArg
@@ -30,8 +30,9 @@ class MethodDir(enum.Enum):
     REQUIRED = enum.auto()
 
 
-type Provided[T] = Annotated[T, MethodDir.PROVIDED]
-type Required[T] = Annotated[T, MethodDir.REQUIRED]
+_T = TypeVar("_T")
+Provided: TypeAlias = Annotated[_T, MethodDir.PROVIDED]
+Required: TypeAlias = Annotated[_T, MethodDir.REQUIRED]
 
 
 class Method(TransactionBase["Transaction | Method"]):

--- a/transactron/core/transaction_base.py
+++ b/transactron/core/transaction_base.py
@@ -1,9 +1,7 @@
 from enum import Enum, auto
 from dataclasses import KW_ONLY, dataclass
 from typing import (
-    Generic,
     Protocol,
-    TypeVar,
     runtime_checkable,
 )
 from amaranth_types import SrcLoc
@@ -12,9 +10,6 @@ from transactron.graph import Owned
 
 
 __all__ = ["TransactionBase", "Priority"]
-
-
-_T = TypeVar("_T", bound="TransactionBase")
 
 
 class Priority(Enum):
@@ -27,26 +22,26 @@ class Priority(Enum):
 
 
 @dataclass
-class RelationBase(Generic[_T]):
+class RelationBase[T: TransactionBase]:
     _: KW_ONLY
-    end: _T
+    end: T
     priority: Priority = Priority.UNDEFINED
     conflict: bool = False
     silence_warning: bool = False
 
 
 @dataclass
-class Relation(RelationBase[_T], Generic[_T]):
+class Relation[T: TransactionBase](RelationBase[T]):
     _: KW_ONLY
-    start: _T
+    start: T
 
 
 @runtime_checkable
-class TransactionBase(Owned, Protocol, Generic[_T]):
+class TransactionBase[T: TransactionBase](Owned, Protocol):
     src_loc: SrcLoc
-    relations: list[RelationBase[_T]]
-    simultaneous_list: list[_T]
-    independent_list: list[_T]
+    relations: list[RelationBase[T]]
+    simultaneous_list: list[T]
+    independent_list: list[T]
 
     def __init__(self, *, src_loc: SrcLoc):
         self.src_loc = src_loc
@@ -54,7 +49,7 @@ class TransactionBase(Owned, Protocol, Generic[_T]):
         self.simultaneous_list = []
         self.independent_list = []
 
-    def add_conflict(self, end: _T, priority: Priority = Priority.UNDEFINED) -> None:
+    def add_conflict(self, end: T, priority: Priority = Priority.UNDEFINED) -> None:
         """Registers a conflict.
 
         Record that that the given `Transaction` or `Method` cannot execute
@@ -73,7 +68,7 @@ class TransactionBase(Owned, Protocol, Generic[_T]):
             RelationBase(end=end, priority=priority, conflict=True, silence_warning=self.owner != end.owner)
         )
 
-    def schedule_before(self, end: _T) -> None:
+    def schedule_before(self, end: T) -> None:
         """Adds a priority relation.
 
         Record that that the given `Transaction` or `Method` needs to be
@@ -89,7 +84,7 @@ class TransactionBase(Owned, Protocol, Generic[_T]):
             RelationBase(end=end, priority=Priority.LEFT, conflict=False, silence_warning=self.owner != end.owner)
         )
 
-    def simultaneous(self, *others: _T) -> None:
+    def simultaneous(self, *others: T) -> None:
         """Adds simultaneity relations.
 
         The given `Transaction`\\s or `Method``\\s will execute simultaneously
@@ -104,7 +99,7 @@ class TransactionBase(Owned, Protocol, Generic[_T]):
         for other in others:
             other.simultaneous_list.append(self)  # type: ignore
 
-    def simultaneous_alternatives(self, *others: _T) -> None:
+    def simultaneous_alternatives(self, *others: T) -> None:
         """Adds exclusive simultaneity relations.
 
         Each of the given `Transaction`\\s or `Method``\\s will execute
@@ -121,7 +116,7 @@ class TransactionBase(Owned, Protocol, Generic[_T]):
         self.simultaneous(*others)
         others[0]._independent(*others[1:])
 
-    def _independent(self, *others: _T) -> None:
+    def _independent(self, *others: T) -> None:
         """Adds independence relations.
 
         This `Transaction` or `Method`, together with all the given

--- a/transactron/testing/input_generation.py
+++ b/transactron/testing/input_generation.py
@@ -1,6 +1,5 @@
 from amaranth import *
 from amaranth.lib.data import StructLayout
-from typing import TypeVar
 import hypothesis.strategies as st
 from hypothesis.strategies import composite, DrawFn, integers, SearchStrategy
 from transactron.utils import MethodLayout, RecordIntDict
@@ -11,11 +10,8 @@ class OpNOP:
         return "OpNOP()"
 
 
-T = TypeVar("T")
-
-
 @composite
-def generate_shrinkable_list(draw: DrawFn, length: int, generator: SearchStrategy[T]) -> list[T]:
+def generate_shrinkable_list[T](draw: DrawFn, length: int, generator: SearchStrategy[T]) -> list[T]:
     """
     Trick based on https://github.com/HypothesisWorks/hypothesis/blob/
     6867da71beae0e4ed004b54b92ef7c74d0722815/hypothesis-python/src/hypothesis/stateful.py#L143
@@ -72,7 +68,7 @@ def insert_nops(draw: DrawFn, max_nops: int, lst: list):
 
 
 @composite
-def generate_nops_in_list(draw: DrawFn, max_nops: int, generate_list: SearchStrategy[list[T]]) -> list[T | OpNOP]:
+def generate_nops_in_list[T](draw: DrawFn, max_nops: int, generate_list: SearchStrategy[list[T]]) -> list[T | OpNOP]:
     lst = draw(generate_list)
     out_lst = []
     out_lst = insert_nops(draw, max_nops, out_lst)

--- a/transactron/testing/test_circuit.py
+++ b/transactron/testing/test_circuit.py
@@ -1,6 +1,6 @@
 from collections.abc import Iterable
 import inspect
-from typing import TypeVar, Generic, TypeGuard, Any, TypeAlias
+from typing import TypeGuard, Any
 from amaranth import *
 from amaranth.sim import *
 from transactron.core.method import MethodDir
@@ -16,11 +16,10 @@ from amaranth_types import HasElaborate
 __all__ = ["SimpleTestCircuit"]
 
 
-T = TypeVar("T")
-_T_nested_collection: TypeAlias = T | list["_T_nested_collection[T]"] | dict[str, "_T_nested_collection[T]"]
+type _T_nested_collection[T] = T | list["_T_nested_collection[T]"] | dict[str, "_T_nested_collection[T]"]
 
 
-def guard_nested_collection(cont: Any, *t: type[T]) -> TypeGuard[_T_nested_collection[T]]:
+def guard_nested_collection[T](cont: Any, *t: type[T]) -> TypeGuard[_T_nested_collection[T]]:
     if isinstance(cont, (list, dict)):
         if isinstance(cont, dict):
             cont = cont.values()
@@ -31,11 +30,8 @@ def guard_nested_collection(cont: Any, *t: type[T]) -> TypeGuard[_T_nested_colle
         return False
 
 
-_T_HasElaborate = TypeVar("_T_HasElaborate", bound=HasElaborate)
-
-
-class SimpleTestCircuit(Elaboratable, Generic[_T_HasElaborate]):
-    def __init__(self, dut: _T_HasElaborate, *, exclude: Iterable[str] = ()):
+class SimpleTestCircuit[T: HasElaborate](Elaboratable):
+    def __init__(self, dut: T, *, exclude: Iterable[str] = ()):
         self._dut = dut
         self._io: dict[str, _T_nested_collection[TestbenchIO]] = {}
         self._exclude = set(exclude)

--- a/transactron/utils/amaranth_ext/component_interface.py
+++ b/transactron/utils/amaranth_ext/component_interface.py
@@ -3,7 +3,7 @@ from amaranth.lib.wiring import Signature, Flow, Member
 from amaranth_types import AbstractInterface, AbstractSignature, FlatShapeLike
 
 from abc import ABCMeta
-from typing import TYPE_CHECKING, Generic, Mapping, Self, TypeVar, final, overload
+from typing import TYPE_CHECKING, Mapping, Self, final, overload
 from dataclasses import dataclass
 
 __all__ = [
@@ -13,8 +13,6 @@ __all__ = [
     "ComponentInterface",
     "FlippedComponentInterface",
 ]
-
-T = TypeVar("T")
 
 
 class _ShapeTypingMeta(ABCMeta):
@@ -32,7 +30,7 @@ class _ShapeTypingMeta(ABCMeta):
         # Amaranth ShapeCastable Signal creation rules
 
         @overload
-        def __call__(cls, shape: ShapeCastable[T]) -> T: ...
+        def __call__[T](cls, shape: ShapeCastable[T]) -> T: ...
 
         @overload
         def __call__(cls, shape: FlatShapeLike = unsigned(1)) -> Signal: ...
@@ -159,17 +157,14 @@ class ComponentInterface(AbstractComponentInterface):
         return res
 
 
-_T_ComponentInterface = TypeVar("_T_ComponentInterface", bound=ComponentInterface)
-
-
 @final
-class FlippedComponentInterface(AbstractComponentInterface, Generic[_T_ComponentInterface]):
+class FlippedComponentInterface[T: ComponentInterface](AbstractComponentInterface):
     """
     Represents `ComponentInterface` with flipped `Flow` directions of its members.
     Flip is applied only in resulting `signature` property.
     """
 
-    def __init__(self, base: _T_ComponentInterface):
+    def __init__(self, base: T):
         self._base = base
 
     def __getattr__(self, name: str):
@@ -180,6 +175,6 @@ class FlippedComponentInterface(AbstractComponentInterface, Generic[_T_Component
         """Amaranth lib.wiring `Signature` constructed from defined `ComponentInterface` attributes."""
         return self._base.signature.flip()
 
-    def flipped(self) -> _T_ComponentInterface:
+    def flipped(self) -> T:
         """`ComponentInterface` with flipped `Flow` direction of members."""
         return self._base

--- a/transactron/utils/amaranth_ext/shifter.py
+++ b/transactron/utils/amaranth_ext/shifter.py
@@ -1,7 +1,7 @@
 from amaranth import *
 from amaranth.hdl import ValueCastable
 from collections.abc import Sequence
-from typing import Optional, TypeVar, cast, overload
+from typing import Optional, cast, overload
 from amaranth_types import ValueLike, FlatValueLike
 from .functions import shape_of, const_of
 
@@ -20,9 +20,6 @@ __all__ = [
     "rotate_vec_right",
     "rotate_vec_left",
 ]
-
-
-_T_ValueCastable = TypeVar("_T_ValueCastable", bound=ValueCastable)
 
 
 def generic_shift_right(value1: ValueLike, value2: ValueLike, offset: ValueLike) -> Value:
@@ -188,9 +185,9 @@ def rotate_left(value: ValueLike, offset: ValueLike) -> Value:
 
 
 @overload
-def generic_shift_vec_right(
-    data1: Sequence[_T_ValueCastable], data2: Sequence[_T_ValueCastable], offset: ValueLike
-) -> Sequence[_T_ValueCastable]: ...
+def generic_shift_vec_right[
+    T: ValueCastable
+](data1: Sequence[T], data2: Sequence[T], offset: ValueLike) -> Sequence[T]: ...
 
 
 @overload
@@ -250,9 +247,9 @@ def generic_shift_vec_right(
 
 
 @overload
-def generic_shift_vec_left(
-    data1: Sequence[_T_ValueCastable], data2: Sequence[_T_ValueCastable], offset: ValueLike
-) -> Sequence[_T_ValueCastable]: ...
+def generic_shift_vec_left[
+    T: ValueCastable
+](data1: Sequence[T], data2: Sequence[T], offset: ValueLike) -> Sequence[T]: ...
 
 
 @overload
@@ -291,9 +288,9 @@ def generic_shift_vec_left(
 
 
 @overload
-def shift_vec_right(
-    data: Sequence[_T_ValueCastable], offset: ValueLike, placeholder: Optional[_T_ValueCastable]
-) -> Sequence[_T_ValueCastable]: ...
+def shift_vec_right[
+    T: ValueCastable
+](data: Sequence[T], offset: ValueLike, placeholder: Optional[T]) -> Sequence[T]: ...
 
 
 @overload
@@ -337,9 +334,7 @@ def shift_vec_right(
 
 
 @overload
-def shift_vec_left(
-    data: Sequence[_T_ValueCastable], offset: ValueLike, placeholder: Optional[_T_ValueCastable]
-) -> Sequence[_T_ValueCastable]: ...
+def shift_vec_left[T: ValueCastable](data: Sequence[T], offset: ValueLike, placeholder: Optional[T]) -> Sequence[T]: ...
 
 
 @overload
@@ -379,7 +374,7 @@ def shift_vec_left(
 
 
 @overload
-def rotate_vec_right(data: Sequence[_T_ValueCastable], offset: ValueLike) -> Sequence[_T_ValueCastable]: ...
+def rotate_vec_right[T: ValueCastable](data: Sequence[T], offset: ValueLike) -> Sequence[T]: ...
 
 
 @overload
@@ -409,7 +404,7 @@ def rotate_vec_right(data: Sequence[ValueLike], offset: ValueLike) -> Sequence[V
 
 
 @overload
-def rotate_vec_left(data: Sequence[_T_ValueCastable], offset: ValueLike) -> Sequence[_T_ValueCastable]: ...
+def rotate_vec_left[T: ValueCastable](data: Sequence[T], offset: ValueLike) -> Sequence[T]: ...
 
 
 @overload

--- a/transactron/utils/depcache.py
+++ b/transactron/utils/depcache.py
@@ -1,10 +1,8 @@
-from typing import Callable, TypeVar, Any
+from typing import Callable, Any
 
 from transactron.utils import make_hashable
 
 __all__ = ["DependentCache"]
-
-T = TypeVar("T")
 
 
 class DependentCache:
@@ -26,7 +24,7 @@ class DependentCache:
     def __init__(self):
         self._depcache: dict[tuple[Callable, Any], Any] = {}
 
-    def get(self, cls: Callable[..., T], **kwargs) -> T:
+    def get[T](self, cls: Callable[..., T], **kwargs) -> T:
         cache_key = make_hashable(kwargs)
         v = self._depcache.get((cls, cache_key), None)
         if v is None:

--- a/transactron/utils/dependencies.py
+++ b/transactron/utils/dependencies.py
@@ -1,16 +1,13 @@
 from collections import defaultdict
 
 from abc import abstractmethod, ABC
-from typing import Any, Generic, Optional, TypeVar
+from typing import Any, Optional
 
 
 __all__ = ["DependencyManager", "DependencyKey", "DependencyContext", "SimpleKey", "ListKey"]
 
-T = TypeVar("T")
-U = TypeVar("U")
 
-
-class DependencyKey(Generic[T, U], ABC):
+class DependencyKey[T, U](ABC):
     """Base class for dependency keys.
 
     Dependency keys are used to access dependencies in the `DependencyManager`.
@@ -54,7 +51,7 @@ class DependencyKey(Generic[T, U], ABC):
     empty_valid: bool = False
 
 
-class SimpleKey(Generic[T], DependencyKey[T, T]):
+class SimpleKey[T](DependencyKey[T, T]):
     """Base class for simple dependency keys.
 
     Simple dependency keys are used when there is an one-to-one relation between
@@ -78,7 +75,7 @@ class SimpleKey(Generic[T], DependencyKey[T, T]):
         return data[0]
 
 
-class ListKey(Generic[T], DependencyKey[T, list[T]]):
+class ListKey[T](DependencyKey[T, list[T]]):
     """Base class for list key.
 
     List keys are used when there is an one-to-many relation between keys
@@ -102,7 +99,7 @@ class DependencyManager:
         self.cache: dict[DependencyKey, Any] = {}
         self.locked_dependencies: set[DependencyKey] = set()
 
-    def add_dependency(self, key: DependencyKey[T, Any], dependency: T) -> None:
+    def add_dependency[T](self, key: DependencyKey[T, Any], dependency: T) -> None:
         """Adds a new dependency to a key.
 
         Depending on the key type, a key can have a single dependency or
@@ -117,7 +114,7 @@ class DependencyManager:
         if key in self.cache:
             del self.cache[key]
 
-    def get_dependency(self, key: DependencyKey[Any, U]) -> U:
+    def get_dependency[U](self, key: DependencyKey[Any, U]) -> U:
         """Gets the dependency for a key.
 
         The way dependencies are interpreted is dependent on the key type.
@@ -129,7 +126,7 @@ class DependencyManager:
 
         return ret
 
-    def get_optional_dependency(self, key: DependencyKey[Any, U]) -> Optional[U]:
+    def get_optional_dependency[U](self, key: DependencyKey[Any, U]) -> Optional[U]:
         """Gets the dependency for a key, if it exists.
 
         If the dependency is gettable, the return value is the same as in

--- a/transactron/utils/transactron_helpers.py
+++ b/transactron/utils/transactron_helpers.py
@@ -1,6 +1,6 @@
 import sys
 from contextlib import contextmanager
-from typing import Optional, Any, Concatenate, TypeGuard, TypeVar
+from typing import Optional, Any, Concatenate, TypeGuard
 from collections.abc import Callable, Mapping, Sequence
 from .typing import ROGraph, GraphCC, MethodLayout, MethodStruct, LayoutList, LayoutListField
 from amaranth_types import SrcLoc, ShapeLike
@@ -8,7 +8,7 @@ from inspect import Parameter, signature
 from itertools import count
 from amaranth import *
 from amaranth import tracer
-from amaranth.lib.data import StructLayout
+from amaranth.lib.data import StructLayout, View
 import amaranth.lib.data as data
 import dataclasses
 
@@ -29,11 +29,8 @@ __all__ = [
     "dataclass_asdict",
 ]
 
-T = TypeVar("T")
-U = TypeVar("U")
 
-
-def _graph_ccs(gr: ROGraph[T]) -> list[GraphCC[T]]:
+def _graph_ccs[T](gr: ROGraph[T]) -> list[GraphCC[T]]:
     """_graph_ccs
 
     Find connected components in a graph.
@@ -69,7 +66,7 @@ def _graph_ccs(gr: ROGraph[T]) -> list[GraphCC[T]]:
     return ccs
 
 
-def longest_common_prefix(*seqs: Sequence[T]) -> Sequence[T]:
+def longest_common_prefix[T](*seqs: Sequence[T]) -> Sequence[T]:
     if not seqs:
         raise ValueError("no arguments")
     for i, letter_group in enumerate(zip(*seqs)):
@@ -78,7 +75,9 @@ def longest_common_prefix(*seqs: Sequence[T]) -> Sequence[T]:
     return min(seqs, key=lambda s: len(s))
 
 
-def has_first_param(func: Callable[..., T], name: str, tp: type[U]) -> TypeGuard[Callable[Concatenate[U, ...], T]]:
+def has_first_param[
+    T, U
+](func: Callable[..., T], name: str, tp: type[U]) -> TypeGuard[Callable[Concatenate[U, ...], T]]:
     parameters = signature(func).parameters
     return (
         len(parameters) >= 1
@@ -88,7 +87,7 @@ def has_first_param(func: Callable[..., T], name: str, tp: type[U]) -> TypeGuard
     )
 
 
-def def_helper(description, func: Callable[..., T], tp: type[U], arg: U, /, **kwargs) -> T:
+def def_helper[T, U](description, func: Callable[..., T], tp: type[U], arg: U, /, **kwargs) -> T:
     try:
         parameters = signature(func).parameters
     except ValueError:
@@ -105,20 +104,20 @@ def def_helper(description, func: Callable[..., T], tp: type[U], arg: U, /, **kw
         raise TypeError(f"Invalid {description}: {func}")
 
 
-def mock_def_helper(tb, func: Callable[..., T], arg: Mapping[str, Any]) -> T:
+def mock_def_helper[T](tb, func: Callable[..., T], arg: Mapping[str, Any]) -> T:
     return def_helper(f"mock definition for {tb}", func, Mapping[str, Any], arg, **arg)
 
 
-def async_mock_def_helper(tb, func: Callable[..., T], arg: "data.Const[StructLayout]") -> T:
+def async_mock_def_helper[T](tb, func: Callable[..., T], arg: "data.Const[StructLayout]") -> T:
     marg = {}
     for k, _ in arg.shape():
         marg[k] = arg[k]
     return def_helper(f"mock definition for {tb}", func, Mapping[str, Any], marg, **marg)
 
 
-def method_def_helper(method, func: Callable[..., T], arg: MethodStruct) -> T:
+def method_def_helper[T](method, func: Callable[..., T], arg: MethodStruct) -> T:
     kwargs = {k: arg[k] for k in arg.shape().members}
-    return def_helper(f"method definition for {method}", func, MethodStruct, arg, **kwargs)
+    return def_helper(f"method definition for {method}", func, View[StructLayout], arg, **kwargs)
 
 
 def get_caller_class_name(default: Optional[str] = None) -> tuple[Optional[Elaboratable], str]:

--- a/transactron/utils/transactron_helpers.py
+++ b/transactron/utils/transactron_helpers.py
@@ -8,7 +8,7 @@ from inspect import Parameter, signature
 from itertools import count
 from amaranth import *
 from amaranth import tracer
-from amaranth.lib.data import StructLayout, View
+from amaranth.lib.data import StructLayout
 import amaranth.lib.data as data
 import dataclasses
 
@@ -117,7 +117,7 @@ def async_mock_def_helper[T](tb, func: Callable[..., T], arg: "data.Const[Struct
 
 def method_def_helper[T](method, func: Callable[..., T], arg: MethodStruct) -> T:
     kwargs = {k: arg[k] for k in arg.shape().members}
-    return def_helper(f"method definition for {method}", func, View[StructLayout], arg, **kwargs)
+    return def_helper(f"method definition for {method}", func, MethodStruct, arg, **kwargs)  # type: ignore
 
 
 def get_caller_class_name(default: Optional[str] = None) -> tuple[Optional[Elaboratable], str]:

--- a/transactron/utils/typing.py
+++ b/transactron/utils/typing.py
@@ -2,6 +2,7 @@ from typing import (
     Callable,
     Concatenate,
     Protocol,
+    TypeAlias,
     cast,
     runtime_checkable,
     Union,
@@ -35,7 +36,7 @@ type LayoutListField = tuple[str, "ShapeLike | LayoutList"]
 type LayoutList = list["LayoutListField"]
 type LayoutIterable = Iterable["LayoutListField"]
 type MethodLayout = StructLayout | LayoutIterable
-type MethodStruct = "View[StructLayout]"
+MethodStruct: TypeAlias = "View[StructLayout]"
 
 type RecordIntDict = Mapping[str, Union[int, "RecordIntDict"]]
 type RecordIntDictRet = Mapping[str, Any]  # full typing hard to work with

--- a/transactron/utils/typing.py
+++ b/transactron/utils/typing.py
@@ -1,10 +1,7 @@
 from typing import (
     Callable,
     Concatenate,
-    ParamSpec,
     Protocol,
-    TypeAlias,
-    TypeVar,
     cast,
     runtime_checkable,
     Union,
@@ -32,26 +29,22 @@ __all__ = [
     "HasDebugSignals",
 ]
 
-# Internal Coreblocks types
-ValueBundle: TypeAlias = Value | Record | View | Iterable["ValueBundle"] | Mapping[str, "ValueBundle"]
-LayoutListField: TypeAlias = tuple[str, "ShapeLike | LayoutList"]
-LayoutList: TypeAlias = list["LayoutListField"]
-LayoutIterable: TypeAlias = Iterable["LayoutListField"]
-MethodLayout: TypeAlias = StructLayout | LayoutIterable
-MethodStruct: TypeAlias = "View[StructLayout]"
+# Internal Transactron types
+type ValueBundle = Value | Record | View | Iterable["ValueBundle"] | Mapping[str, "ValueBundle"]
+type LayoutListField = tuple[str, "ShapeLike | LayoutList"]
+type LayoutList = list["LayoutListField"]
+type LayoutIterable = Iterable["LayoutListField"]
+type MethodLayout = StructLayout | LayoutIterable
+type MethodStruct = "View[StructLayout]"
 
-RecordIntDict: TypeAlias = Mapping[str, Union[int, "RecordIntDict"]]
-RecordIntDictRet: TypeAlias = Mapping[str, Any]  # full typing hard to work with
-RecordValueDict: TypeAlias = Mapping[str, Union[ValueLike, "RecordValueDict"]]
-RecordDict: TypeAlias = ValueLike | Mapping[str, "RecordDict"]
+type RecordIntDict = Mapping[str, Union[int, "RecordIntDict"]]
+type RecordIntDictRet = Mapping[str, Any]  # full typing hard to work with
+type RecordValueDict = Mapping[str, Union[ValueLike, "RecordValueDict"]]
+type RecordDict = ValueLike | Mapping[str, "RecordDict"]
 
-T = TypeVar("T")
-U = TypeVar("U")
-P = ParamSpec("P")
-
-ROGraph: TypeAlias = Mapping[T, Iterable[T]]
-Graph: TypeAlias = dict[T, set[T]]
-GraphCC: TypeAlias = set[T]
+type ROGraph[T] = Mapping[T, Iterable[T]]
+type Graph[T] = dict[T, set[T]]
+type GraphCC[T] = set[T]
 
 
 @runtime_checkable
@@ -59,22 +52,24 @@ class HasDebugSignals(Protocol):
     def debug_signals(self) -> ValueBundle: ...
 
 
-def type_self_kwargs_as(as_func: Callable[Concatenate[Any, P], Any]):
+def type_self_kwargs_as[**P](as_func: Callable[Concatenate[Any, P], Any]):
     """
     Decorator used to annotate `**kwargs` type to be the same as named arguments from `as_func` method.
 
     Works only with methods with (self, **kwargs) signature. `self` parameter is also required in `as_func`.
     """
 
-    def return_func(func: Callable[Concatenate[Any, ...], T]) -> Callable[Concatenate[Any, P], T]:
+    def return_func[T](func: Callable[Concatenate[Any, ...], T]) -> Callable[Concatenate[Any, P], T]:
         return cast(Callable[Concatenate[Any, P], T], func)
 
     return return_func
 
 
-def type_self_add_1pos_kwargs_as(
-    as_func: Callable[Concatenate[Any, P], Any]
-) -> Callable[[Callable[Concatenate[Any, T, ...], U]], Callable[Concatenate[Any, T, P], U]]:
+def type_self_add_1pos_kwargs_as[
+    **P, T, U
+](as_func: Callable[Concatenate[Any, P], Any]) -> Callable[
+    [Callable[Concatenate[Any, T, ...], U]], Callable[Concatenate[Any, T, P], U]
+]:
     """
     Decorator used to annotate `**kwargs` type to be the same as named arguments from `as_func` method.
 

--- a/transactron/utils/typing.py
+++ b/transactron/utils/typing.py
@@ -36,7 +36,7 @@ type LayoutListField = tuple[str, "ShapeLike | LayoutList"]
 type LayoutList = list["LayoutListField"]
 type LayoutIterable = Iterable["LayoutListField"]
 type MethodLayout = StructLayout | LayoutIterable
-MethodStruct: TypeAlias = "View[StructLayout]"
+MethodStruct: TypeAlias = "View[StructLayout]"  # defined as TypeAlias because of def_method logic
 
 type RecordIntDict = Mapping[str, Union[int, "RecordIntDict"]]
 type RecordIntDictRet = Mapping[str, Any]  # full typing hard to work with


### PR DESCRIPTION
I'm doing all my work on Coreblocks and Transactron on Python 3.13 for some time with no issues. It's probably time to change it to be the default. Why not 3.14? Not yet available in stable Debian ;)

New generic type and type alias syntax can finally be used.