### PR TITLE
Make CtrlPath hashable

### DIFF
--- a/transactron/core/body.py
+++ b/transactron/core/body.py
@@ -37,7 +37,7 @@ class Body(TransactionBase["Body"]):
     def_counter: ClassVar[count] = count()
     def_order: int
     stack: ClassVar[list["Body"]] = []
-    ctrl_path: CtrlPath = CtrlPath(-1, [])
+    ctrl_path: CtrlPath = CtrlPath(-1, ())
     method_uses: dict["Method", tuple[MethodStruct, Signal]]
     method_calls: defaultdict["Method", list[tuple[CtrlPath, MethodStruct, ValueLike]]]
     conditional_calls: set["Method"]

--- a/transactron/core/tmodule.py
+++ b/transactron/core/tmodule.py
@@ -83,12 +83,12 @@ class CtrlPath:
     ----------
     module : int
         Unique number of the module the path refers to.
-    path : list[PathEdge]
+    path : tuple[PathEdge, ...]
         Path in the control tree, starting from the root.
     """
 
     module: int
-    path: list[PathEdge]
+    path: tuple[PathEdge, ...]
 
     def is_prefix(self, other: "CtrlPath"):
         """Decides if this path is a prefix of some other path.
@@ -181,7 +181,7 @@ class CtrlPathBuilder:
 
     def build_ctrl_path(self):
         """Returns the current control path."""
-        return CtrlPath(self.module, self.ctrl_path[:])
+        return CtrlPath(self.module, tuple(self.ctrl_path))
 
 
 class TModule(ModuleLike, Elaboratable):


### PR DESCRIPTION
This PR makes `CtrlPath` hashable by replacing the internal `list` by a `tuple`. Reasoning:

* @qbojj had an issue with this in #141.
* It's a frozen dataclass anyway, and making this field immutable safeguards the code against possible future bugs.
* `CtrlPathBuilder` copies the lists anyway, for the purpose of avoiding mutation. They can be made into tuples then.