### PR TITLE
add `src_loc` to exception messages in core

### DIFF
--- a/transactron/core/manager.py
+++ b/transactron/core/manager.py
@@ -204,7 +204,10 @@ class TransactionManager(Elaboratable):
             end = relation.end
             if not relation.conflict:  # relation added with schedule_before
                 if end.def_order < start.def_order and not relation.silence_warning:
-                    raise RuntimeError(f"{start.name!r} scheduled before {end.name!r}, but defined afterwards")
+                    raise RuntimeError(
+                        f"{start.name!r} {start.src_loc} scheduled before {end.name!r} {end.src_loc} "
+                        "but defined afterwards"
+                    )
 
             for trans_start in method_map.transactions_for(start):
                 for trans_end in method_map.transactions_for(end):
@@ -321,7 +324,8 @@ class TransactionManager(Elaboratable):
                 # nested definitions do not trigger the issue
                 if any(not elem.ctrl_path.is_proper_prefix(sim_elem.ctrl_path) for sim_elem in elem.simultaneous_list):
                     raise RuntimeError(
-                        f"Simultaneity constraint for conditionally called method '{elem.name}' not supported"
+                        "Simultaneity constraint for conditionally called method "
+                        f"'{elem.name}' {elem.src_loc} not supported"
                     )
             pruned_sim = False
             for sim_elem in elem.simultaneous_list:
@@ -333,7 +337,10 @@ class TransactionManager(Elaboratable):
                 for tr1, tr2 in product(method_map.transactions_for(elem), method_map.transactions_for(sim_elem)):
                     if tr1 in independents[tr2]:
                         raise RuntimeError(
-                            f"Unsatisfiable simultaneity constraints for '{elem.name}' and '{sim_elem.name}'"
+                            textwrap.dedent(
+                                f"Unsatisfiable simultaneity constraints for '{elem.name}' {elem.src_loc} "
+                                f"and '{sim_elem.name}' {sim_elem.src_loc}"
+                            )
                         )
                     simultaneous.add(frozenset({tr1, tr2}))
             if pruned_sim and elem in method_map.transactions:
@@ -460,7 +467,7 @@ class TransactionManager(Elaboratable):
 
         for method in method_map.methods:
             if method.single_caller and len(method_args[method]) > 1:
-                raise RuntimeError(f"Single-caller method '{method.name}' called more than once")
+                raise RuntimeError(f"Single-caller method '{method.name}' {method.src_loc} called more than once")
             runs = Cat(method_runs[method])
             m.d.comb += assign(method.data_in, method.combiner(m, method_args[method], runs), fields=AssignType.ALL)
 

--- a/transactron/core/method.py
+++ b/transactron/core/method.py
@@ -137,11 +137,11 @@ class Method(TransactionBase["Transaction | Method"]):
         if isinstance(self._body_ptr, Method):
             self._body_ptr = self._body_ptr._body
             return self._body_ptr
-        raise RuntimeError(f"Method '{self.name}' not defined")
+        raise RuntimeError(f"Method '{self.name}' {self.src_loc} not defined")
 
     def _set_impl(self, value: "Body | Method"):
         if self._body_ptr is not None:
-            raise RuntimeError(f"Method '{self.name}' already defined")
+            raise RuntimeError(f"Method '{self.name}' {self.src_loc} already defined")
         if value.data_in.shape() != self.layout_in or value.data_out.shape() != self.layout_out:
             raise ValueError(
                 textwrap.dedent(
@@ -319,7 +319,10 @@ class Method(TransactionBase["Transaction | Method"]):
 
         caller = Body.get()
         if not all(ctrl_path.exclusive_with(m.ctrl_path) for ctrl_path, _, _ in caller.method_calls[self]):
-            raise RuntimeError(f"Method '{self.name}' can't be called twice from the same caller '{caller.name}'")
+            raise RuntimeError(
+                f"Method '{self.name}' {self.src_loc} can't be called twice "
+                f"from the same caller '{caller.name}' {caller.src_loc}"
+            )
         caller.method_calls[self].append((m.ctrl_path, arg_rec, enable_sig))
 
         is_conditional = (

--- a/transactron/core/transaction.py
+++ b/transactron/core/transaction.py
@@ -86,13 +86,13 @@ class Transaction(TransactionBase["Transaction | Method"]):
     def _body(self) -> TBody:
         if self._body_ptr is not None:
             return TBody(self._body_ptr)
-        raise RuntimeError(f"Method '{self.name}' not defined")
+        raise RuntimeError(f"Transaction '{self.name}' {self.src_loc} not defined")
 
     def _set_impl(self, m: TModule, value: Body):
         if self._body_ptr is not None:
-            raise RuntimeError(f"Transaction '{self.name}' already defined")
+            raise RuntimeError(f"Transaction '{self.name}' {self.src_loc} already defined")
         if value.data_in.shape().size != 0 or value.data_out.shape().size != 0:
-            raise ValueError(f"Transaction body {value.name} has invalid interface")
+            raise ValueError(f"Transaction body {value.name} {value.src_loc} has invalid interface")
         self._body_ptr = value
         m.d.top_comb += self.ready.eq(value.ready)
         m.d.top_comb += self.runnable.eq(value.runnable)


### PR DESCRIPTION
adds `src_loc` to every error message in core.
Otherwise it's **very** annoying to debug when multiple instances of some object is used. 