### PR TITLE
Special case for validate arguments with 1 call

### DIFF
--- a/transactron/core/manager.py
+++ b/transactron/core/manager.py
@@ -502,10 +502,14 @@ class TransactionManager(Elaboratable):
                 arg_rec = Signal.like(method.data_in)
                 en = Signal()
 
-                # Only one call can be active per method and transaction due to call-path exclusivity.
-                for i in OneHotSwitchDynamic(m, Cat(call.enable for call in calls)):
-                    m.d.comb += arg_rec.eq(calls[i].arg)
+                if len(calls) == 1:
+                    m.d.comb += arg_rec.eq(calls[0].arg)
                     m.d.comb += en.eq(1)
+                else:
+                    # Only one call can be active per method and transaction due to call-path exclusivity.
+                    for i in OneHotSwitchDynamic(m, Cat(call.enable for call in calls)):
+                        m.d.comb += arg_rec.eq(calls[i].arg)
+                        m.d.comb += en.eq(1)
 
                 return method._validate_arguments(en, arg_rec)
 


### PR DESCRIPTION
Adds a special case to `validate_args_for_method` to avoid creating circular logic in some use cases. This mirrors the special case in `core/body`.