### PR TITLE
Testing dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,9 @@ dependencies = [
     "amaranth-stubs ~= 0.5.0.0",
     "dataclasses-json ~= 0.6.3",
     "tabulate ~= 0.9.0",
-    "networkx ~= 3.4.2"
+    "networkx ~= 3.4.2",
+    "pytest ~= 8.0.0",
+    "hypothesis ~= 6.99.6"
 ]
 requires-python = ">=3.13"
 classifiers = [
@@ -34,9 +36,7 @@ dev = [
     "flake8 == 7.0.0",
     "black == 24.4.2",
     # Testing
-    "pytest == 8.0.0",
     "pytest-xdist == 3.5.0",
-    "hypothesis == 6.99.6",
     # Documentation
     "pep8-naming == 0.13.3",
     "Sphinx == 8.2.3",


### PR DESCRIPTION
This PR moves `pytest` and `hypothesis` to dependencies. This is the simplest solution of the optional dependency problem for the `testing` submodule.