### PR TITLE
Interfaces

### DIFF
--- a/test/core/test_methods.py
+++ b/test/core/test_methods.py
@@ -129,13 +129,11 @@ class TestDefMethod(TestCaseWithSimulator):
 class TestDefMethods(TestCaseWithSimulator):
     class CircuitTestModule(Elaboratable):
         def __init__(self, method_definition):
-            self.methods = [
-                Method(
-                    i=[("foo", 3)],
-                    o=[("foo", 3)],
-                )
-                for _ in range(4)
-            ]
+            self.methods = Methods(
+                4,
+                i=[("foo", 3)],
+                o=[("foo", 3)],
+            )
 
             self.method_definition = method_definition
 

--- a/transactron/core/__init__.py
+++ b/transactron/core/__init__.py
@@ -6,3 +6,4 @@ from .manager import *  # noqa: F401
 from .context import *  # noqa: F401
 from .sugar import *  # noqa: F401
 from .body import *  # noqa: F401
+from .interface import *  # noqa: F401

--- a/transactron/core/interface.py
+++ b/transactron/core/interface.py
@@ -1,62 +1,77 @@
 import inspect
-from collections.abc import Sequence, Mapping
+from collections.abc import Iterable, Sequence, Mapping
 from typing import Any, final, overload
 from dataclasses import dataclass
-
-from amaranth_types import HasElaborate
 from .method import Method, Methods, MethodDir
 
 
-__all__ = ["Interface", "InterfaceMember", "interface"]
+__all__ = ["Interface", "InterfacePart", "InterfaceMember", "interface"]
 
-
-type Interface = Method | Sequence["InterfaceMember"] | Mapping[str, "InterfaceMember"]
 
 @final
 @dataclass
 class InterfaceMember:
-    dir: MethodDir
-    iface: Interface
+    mdir: MethodDir
+    iface: "InterfacePart"
 
 
-@overload
-def interface(obj: Method) -> Method:
-    ...
+# TODO: when frozendicts are introduced, use here
+@final
+class Interface(Mapping[str, "InterfaceMember"]):
+    def __init__(self, members: Iterable[tuple[str, "InterfaceMember"]]):
+        self._dict = dict(members)
 
-@overload
-def interface(obj: Sequence) -> Sequence[InterfaceMember]:
-    ...
+    def __len__(self):
+        return len(self._dict)
 
-@overload
-def interface(obj: Mapping) -> Mapping[str, InterfaceMember]:
-    ...
+    def __getitem__(self, name: str):
+        return self._dict[name]
 
-@overload
-def interface(obj: HasElaborate) -> Mapping[str, InterfaceMember]:
-    ...
+    def __iter__(self):
+        return iter(self._dict)
+
+
+type InterfacePart = Method | Interface | Sequence["InterfacePart"] | Mapping[str, "InterfacePart"]
+
 
 def interface(obj) -> Interface:
+    hints: dict[str, Any] = {}
+    for cls in reversed(obj.__class__.__mro__):
+        hints.update(inspect.get_annotations(cls, eval_str=True))
+
+    ret: dict[str, InterfaceMember] = {}
+
+    for name, attr in vars(obj).items():
+        if name in hints and hasattr(hints[name], "__metadata__"):
+            dirs = [dir for dir in hints[name].__metadata__ if isinstance(dir, MethodDir)]
+            if len(dirs) != 1:
+                continue
+            ret[name] = InterfaceMember(dirs[0], interface_part(attr))
+        elif isinstance(attr, (Method, Methods)):
+            ret[name] = InterfaceMember(MethodDir.PROVIDED, interface_part(attr))
+
+    return Interface(ret.items())
+
+
+@overload
+def interface_part(obj: Method) -> Method: ...
+
+
+@overload
+def interface_part(obj: Sequence) -> Sequence[InterfacePart]: ...
+
+
+@overload
+def interface_part(obj: Mapping) -> Mapping[str, InterfacePart]: ...
+
+
+def interface_part(obj) -> InterfacePart:
     if isinstance(obj, Method):
         return obj
     elif isinstance(obj, Sequence):
-        return tuple(InterfaceMember(MethodDir.PROVIDED, interface(elem)) for elem in obj)
+        return tuple(interface_part(elem) for elem in obj)
     elif isinstance(obj, Mapping):
         assert all(isinstance(key, str) for key in obj.keys())
-        return {key: InterfaceMember(MethodDir.PROVIDED, interface(elem)) for (key, elem) in obj.items()}
+        return {key: interface_part(elem) for (key, elem) in obj.items()}
     else:
-        hints: dict[str, Any] = {}
-        for cls in reversed(obj.__class__.__mro__):
-            hints.update(inspect.get_annotations(cls, eval_str=True))
-
-        ret: dict[str, InterfaceMember] = {}
-
-        for name, attr in vars(obj).items():
-            if name in hints and hasattr(hints[name], "__metadata__"):
-                dirs = [dir for dir in hints[name].__metadata__ if isinstance(dir, MethodDir)]
-                if len(dirs) != 1:
-                    continue
-                ret[name] = InterfaceMember(dirs[0], interface(attr))
-            elif isinstance(attr, (Method, Methods)):
-                ret[name] = InterfaceMember(MethodDir.PROVIDED, interface(attr))
-
-        return ret
+        return interface(obj)

--- a/transactron/core/interface.py
+++ b/transactron/core/interface.py
@@ -1,0 +1,62 @@
+import inspect
+from collections.abc import Sequence, Mapping
+from typing import Any, final, overload
+from dataclasses import dataclass
+
+from amaranth_types import HasElaborate
+from .method import Method, Methods, MethodDir
+
+
+__all__ = ["Interface", "InterfaceMember", "interface"]
+
+
+type Interface = Method | Sequence["InterfaceMember"] | Mapping[str, "InterfaceMember"]
+
+@final
+@dataclass
+class InterfaceMember:
+    dir: MethodDir
+    iface: Interface
+
+
+@overload
+def interface(obj: Method) -> Method:
+    ...
+
+@overload
+def interface(obj: Sequence) -> Sequence[InterfaceMember]:
+    ...
+
+@overload
+def interface(obj: Mapping) -> Mapping[str, InterfaceMember]:
+    ...
+
+@overload
+def interface(obj: HasElaborate) -> Mapping[str, InterfaceMember]:
+    ...
+
+def interface(obj) -> Interface:
+    if isinstance(obj, Method):
+        return obj
+    elif isinstance(obj, Sequence):
+        return tuple(InterfaceMember(MethodDir.PROVIDED, interface(elem)) for elem in obj)
+    elif isinstance(obj, Mapping):
+        assert all(isinstance(key, str) for key in obj.keys())
+        return {key: InterfaceMember(MethodDir.PROVIDED, interface(elem)) for (key, elem) in obj.items()}
+    else:
+        hints: dict[str, Any] = {}
+        for cls in reversed(obj.__class__.__mro__):
+            hints.update(inspect.get_annotations(cls, eval_str=True))
+
+        ret: dict[str, InterfaceMember] = {}
+
+        for name, attr in vars(obj).items():
+            if name in hints and hasattr(hints[name], "__metadata__"):
+                dirs = [dir for dir in hints[name].__metadata__ if isinstance(dir, MethodDir)]
+                if len(dirs) != 1:
+                    continue
+                ret[name] = InterfaceMember(dirs[0], interface(attr))
+            elif isinstance(attr, (Method, Methods)):
+                ret[name] = InterfaceMember(MethodDir.PROVIDED, interface(attr))
+
+        return ret

--- a/transactron/core/method.py
+++ b/transactron/core/method.py
@@ -29,6 +29,20 @@ class MethodDir(enum.Enum):
     PROVIDED = enum.auto()
     REQUIRED = enum.auto()
 
+    def opposite(self) -> "MethodDir":
+        match self:
+            case MethodDir.PROVIDED:
+                return MethodDir.REQUIRED
+            case MethodDir.REQUIRED:
+                return MethodDir.PROVIDED
+
+    def under(self, other: "MethodDir") -> "MethodDir":
+        match self:
+            case MethodDir.PROVIDED:
+                return other
+            case MethodDir.REQUIRED:
+                return other.opposite()
+
 
 _T = TypeVar("_T")
 Provided: TypeAlias = Annotated[_T, MethodDir.PROVIDED]

--- a/transactron/testing/test_circuit.py
+++ b/transactron/testing/test_circuit.py
@@ -1,13 +1,12 @@
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 import inspect
 from typing import TypeGuard, Any
 from amaranth import *
 from amaranth.sim import *
-from transactron.core.method import MethodDir
 from transactron.lib.adapters import Adapter
 
 from .testbenchio import TestbenchIO
-from transactron import Method, Methods
+from transactron.core import Method, Methods, MethodDir, interface
 from transactron.lib import AdapterTrans
 from transactron.utils import ModuleConnector, auto_debug_signals
 from amaranth_types import HasElaborate
@@ -75,26 +74,14 @@ class SimpleTestCircuit[T: HasElaborate](Elaboratable):
 
         m = Module()
 
-        m.submodules.dut = self._dut
-        hints: dict[str, Any] = {}
-        for cls in reversed(self._dut.__class__.__mro__):
-            hints.update(inspect.get_annotations(cls, eval_str=True))
+        iface = interface(self._dut)
 
-        for name, attr in vars(self._dut).items():
+        for name, member in iface.items():
             if name in self._exclude:
                 continue
-            if guard_nested_collection(attr, Method, Methods) and attr:
-                if (
-                    name in hints
-                    and hasattr(hints[name], "__metadata__")
-                    and MethodDir.REQUIRED in hints[name].__metadata__
-                ):
-                    adapter_type = Adapter
-                else:  # PROVIDED is the default
-                    adapter_type = AdapterTrans
-                tb_cont, mc = transform_methods_to_testbenchios(adapter_type, attr)
-                self._io[name] = tb_cont
-                m.submodules[name] = mc
+            tb_cont, mc = transform_methods_to_testbenchios(member.dir, member.iface)
+            self._io[name] = tb_cont
+            m.submodules[name] = mc
 
         return m
 

--- a/transactron/testing/test_circuit.py
+++ b/transactron/testing/test_circuit.py
@@ -1,13 +1,11 @@
-from collections.abc import Iterable, Mapping
-import inspect
+from collections.abc import Iterable, Mapping, Sequence
 from typing import TypeGuard, Any
 from amaranth import *
 from amaranth.sim import *
-from transactron.lib.adapters import Adapter
+from transactron.lib.adapters import Adapter, AdapterTrans
 
 from .testbenchio import TestbenchIO
-from transactron.core import Method, Methods, MethodDir, interface
-from transactron.lib import AdapterTrans
+from transactron.core import interface, Interface, InterfacePart, MethodDir
 from transactron.utils import ModuleConnector, auto_debug_signals
 from amaranth_types import HasElaborate
 
@@ -29,6 +27,14 @@ def guard_nested_collection[T](cont: Any, *t: type[T]) -> TypeGuard[_T_nested_co
         return False
 
 
+def mdir_adapter_type(mdir: MethodDir) -> type[AdapterTrans] | type[Adapter]:
+    match mdir:
+        case MethodDir.PROVIDED:
+            return AdapterTrans
+        case MethodDir.REQUIRED:
+            return Adapter
+
+
 class SimpleTestCircuit[T: HasElaborate](Elaboratable):
     def __init__(self, dut: T, *, exclude: Iterable[str] = ()):
         self._dut = dut
@@ -43,43 +49,48 @@ class SimpleTestCircuit[T: HasElaborate](Elaboratable):
 
     def elaborate(self, platform):
         def transform_methods_to_testbenchios(
-            adapter_type: type[Adapter] | type[AdapterTrans],
-            container: _T_nested_collection[Method | Methods],
+            mdir: MethodDir,
+            iface: InterfacePart,
         ) -> tuple[
-            _T_nested_collection["TestbenchIO"],
-            "ModuleConnector | TestbenchIO",
+            _T_nested_collection[TestbenchIO],
+            ModuleConnector | TestbenchIO,
         ]:
-            if isinstance(container, list):
-                tb_list = []
-                mc_list = []
-                for elem in container:
-                    tb, mc = transform_methods_to_testbenchios(adapter_type, elem)
-                    tb_list.append(tb)
-                    mc_list.append(mc)
-                return tb_list, ModuleConnector(*mc_list)
-            elif isinstance(container, dict):
-                tb_dict = {}
-                mc_dict = {}
-                for name, elem in container.items():
-                    tb, mc = transform_methods_to_testbenchios(adapter_type, elem)
-                    tb_dict[name] = tb
-                    mc_dict[name] = mc
-                return tb_dict, ModuleConnector(*mc_dict)
-            elif isinstance(container, Methods):
-                tb_list = [TestbenchIO(adapter_type.create(method)) for method in container]
-                return list(tb_list), ModuleConnector(*tb_list)
+            if isinstance(iface, Interface):
+                ntb_dict: dict[str, _T_nested_collection[TestbenchIO]] = {}
+                mc_dict: dict[str, HasElaborate] = {}
+                for name, member in iface.items():
+                    ntb, mod = transform_methods_to_testbenchios(mdir.under(member.mdir), member.iface)
+                    ntb_dict[name] = ntb
+                    mc_dict[name] = mod
+                return ntb_dict, ModuleConnector(**mc_dict)
+            elif isinstance(iface, Sequence):
+                ntb_list: list[_T_nested_collection[TestbenchIO]] = []
+                mod_list: list[HasElaborate] = []
+                for elem in iface:
+                    ntb, mod = transform_methods_to_testbenchios(mdir, elem)
+                    ntb_list.append(ntb)
+                    mod_list.append(mod)
+                return ntb_list, ModuleConnector(*mod_list)
+            elif isinstance(iface, Mapping):
+                ntb_dict: dict[str, _T_nested_collection[TestbenchIO]] = {}
+                mc_dict: dict[str, HasElaborate] = {}
+                for name, elem in iface.items():
+                    ntb, mod = transform_methods_to_testbenchios(mdir, elem)
+                    ntb_dict[name] = ntb
+                    mc_dict[name] = mod
+                return ntb_dict, ModuleConnector(**mc_dict)
             else:
-                tb = TestbenchIO(adapter_type.create(container))
+                tb = TestbenchIO(mdir_adapter_type(mdir).create(iface))
                 return tb, tb
 
         m = Module()
+        m.submodules.dut = self._dut
 
         iface = interface(self._dut)
-
         for name, member in iface.items():
             if name in self._exclude:
                 continue
-            tb_cont, mc = transform_methods_to_testbenchios(member.dir, member.iface)
+            tb_cont, mc = transform_methods_to_testbenchios(member.mdir, member.iface)
             self._io[name] = tb_cont
             m.submodules[name] = mc
 


### PR DESCRIPTION
This PR adds lightweight interfaces to Transactron.

An interface is a list of (provided/required) methods in a given object. To be considered a part of an object's interface, a method must be either:

* Be an attribute of the object.
* Be a part of a complex attribute, which is annotated with `Provided` or `Required`. A complex attribute can be built with arbitrary sequences, mappings or other objects.

`SimpleTestCircuit` is modified to work with interfaces. The old "guessing" method of discovering complex attributes is eliminated.

Interfaces can be used to implement a `connect` function for methods (#172).

Comments welcome.

TODO:
- [ ] Tests
- [ ] Docstrings