### PR TITLE
better one-hot-mux

### DIFF
--- a/test/lib/test_dependency_key.py
+++ b/test/lib/test_dependency_key.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import Required
 
 import pytest
 from transactron.core import *

--- a/test/lib/test_dependency_key.py
+++ b/test/lib/test_dependency_key.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Required
 
 import pytest
 from transactron.core import *

--- a/test/utils/test_amaranth_ext.py
+++ b/test/utils/test_amaranth_ext.py
@@ -43,12 +43,10 @@ def one_hot_mux_reference(select_values, input_values, default_value, is_priorit
                 selected_index = index
                 break
 
+    assert selected_index is not None or default_value is not None, "Invalid select values with no default value"
+
     if selected_index is None:
-        if default_value is not None:
-            return default_value
-        if len(input_values) == 1:
-            return input_values[0]
-        return 0
+        return default_value
 
     return input_values[selected_index]
 

--- a/test/utils/test_amaranth_ext.py
+++ b/test/utils/test_amaranth_ext.py
@@ -1,10 +1,8 @@
-from amaranth import ValueCastable
-
 from transactron.testing import *
 import random
 import pytest
 from amaranth import *
-from amaranth.lib.enum import Enum
+from amaranth.lib.data import ArrayLayout
 from transactron.utils.amaranth_ext import MultiPriorityEncoder, OneHotMux, RingMultiPriorityEncoder
 
 
@@ -31,96 +29,106 @@ def get_expected_ring(input_width, output_count, input, first, last):
     return places
 
 
-class OneHotMuxEnum(Enum, shape=1):
-    ZERO = 0
-    ONE = 1
+def one_hot_mux_reference(select_values, input_values, default_value, is_priority):
+    selected_index = None
+    if is_priority:
+        for index, select in enumerate(select_values):
+            if select:
+                selected_index = index
+                break
+    else:
+        assert sum(1 for select in select_values if select) <= 1
+        for index, select in enumerate(select_values):
+            if select:
+                selected_index = index
+                break
+
+    if selected_index is None:
+        if default_value is not None:
+            return default_value
+        if len(input_values) == 1:
+            return input_values[0]
+        return 0
+
+    return input_values[selected_index]
+
+
+class OneHotMuxDUT(Elaboratable):
+    def __init__(self, shape, input_count, is_priority, has_default):
+        self.select = [Signal() for _ in range(input_count)]
+        self.inputs = [Signal(shape) for _ in range(input_count)]  # type: ignore
+        self.output = Signal(shape)  # type: ignore
+        self.default = Signal(shape) if has_default else None  # type: ignore
+        self.is_priority = is_priority
+        self.has_default = has_default
+
+    def elaborate(self, platform):
+        m = Module()
+        m.d.comb += Value.cast(self.output).eq(
+            OneHotMux.create(
+                m,
+                list(zip(self.select, self.inputs)),
+                self.default if self.has_default else None,
+                priority=self.is_priority,
+            )
+        )
+        return m
 
 
 class TestOneHotMux(TestCaseWithSimulator):
-    def test_values(self):
-        class DUT(Elaboratable):
-            def __init__(self):
-                self.select_0 = Signal()
-                self.select_1 = Signal()
-                self.input_0 = Signal(2)
-                self.input_1 = Signal(2)
-                self.default = Const(3, 2)
-                self.output = Signal(2)
+    @pytest.mark.parametrize("is_valuecastable", [False, True])
+    @pytest.mark.parametrize("has_default", [False, True])
+    @pytest.mark.parametrize("is_priority", [False, True])
+    @pytest.mark.parametrize("input_count", [1, 3, 7])
+    @pytest.mark.parametrize("width", [1, 6, 15])
+    def test_randomized(self, is_valuecastable, has_default, is_priority, input_count, width):
+        random.seed(f"{int(is_valuecastable)}-{int(has_default)}-{int(is_priority)}-{input_count}-{width}")
 
-            def elaborate(self, platform):
-                m = Module()
-                m.d.comb += self.output.eq(
-                    OneHotMux.create(
-                        m,
-                        [(self.select_0, self.input_0), (self.select_1, self.input_1)],
-                        self.default,
-                    )
-                )
-                return m
+        shape = ArrayLayout(1, width) if is_valuecastable else width
+        dut = OneHotMuxDUT(shape=shape, input_count=input_count, is_priority=is_priority, has_default=has_default)
 
-        dut = DUT()
+        def from_repr(x):
+            return shape.from_bits(x) if is_valuecastable else x
 
         async def proc(sim: TestbenchContext):
-            test_vectors = [
-                (0, 0, 1, 2, 3),
-                (1, 0, 1, 2, 1),
-                (0, 1, 1, 2, 2),
-            ]
-            for select_0, select_1, input_0, input_1, expected in test_vectors:
-                sim.set(dut.select_0, select_0)
-                sim.set(dut.select_1, select_1)
-                sim.set(dut.input_0, input_0)
-                sim.set(dut.input_1, input_1)
-                await sim.tick()
-                assert sim.get(dut.output) == expected
+            for _ in range(100):
+                if is_priority:
+                    if has_default:
+                        select = random.randrange(0, 2**input_count)
+                    else:
+                        select = random.randrange(1, 2**input_count)
+                else:
+                    if has_default:
+                        select = random.randrange(0, input_count + 1)
+                        select = 0 if select == input_count else 1 << select
+                    else:
+                        select = 1 << random.randrange(0, input_count)
 
-        with self.run_simulation(dut) as sim:
-            sim.add_testbench(proc)
+                values = [random.randrange(0, 2**width) for _ in range(input_count)]
+                default_value = random.randrange(0, 2**width) if has_default else None
 
-    def test_valuecastables(self):
-        class DUT(Elaboratable):
-            select_0: Value
-            select_1: Value
-            input_0: ValueCastable
-            input_1: ValueCastable
-            default: ValueCastable
-            output: ValueCastable
+                for i in range(input_count):
+                    sim.set(dut.select[i], (select >> i) & 1)
+                    sim.set(dut.inputs[i], from_repr(values[i]))  # type: ignore
 
-            def __init__(self):
-                self.select_0 = Signal()
-                self.select_1 = Signal()
-                self.input_0 = Signal(OneHotMuxEnum)  # type: ignore
-                self.input_1 = Signal(OneHotMuxEnum)  # type: ignore
-                self.default = Signal(OneHotMuxEnum)  # type: ignore
-                self.output = Signal(OneHotMuxEnum)  # type: ignore
+                if has_default:
+                    sim.set(dut.default, from_repr(default_value))  # type: ignore
 
-            def elaborate(self, platform):
-                m = Module()
-                m.d.comb += Value.cast(self.output).eq(
-                    OneHotMux.create(
-                        m,
-                        [(self.select_0, self.input_0), (self.select_1, self.input_1)],
-                        self.default,
-                    )
+                await sim.delay(1e-7)
+
+                got = sim.get(dut.output)
+
+                if is_valuecastable:
+                    got = Const.cast(got).value
+
+                expected = one_hot_mux_reference(
+                    select_values=[(select >> i) & 1 for i in range(input_count)],
+                    input_values=values,
+                    default_value=default_value,
+                    is_priority=is_priority,
                 )
-                return m
 
-        dut = DUT()
-
-        async def proc(sim: TestbenchContext):
-            test_vectors = [
-                (0, 0, OneHotMuxEnum.ZERO, OneHotMuxEnum.ONE, OneHotMuxEnum.ZERO),
-                (1, 0, OneHotMuxEnum.ZERO, OneHotMuxEnum.ONE, OneHotMuxEnum.ZERO),
-                (0, 1, OneHotMuxEnum.ZERO, OneHotMuxEnum.ONE, OneHotMuxEnum.ONE),
-            ]
-            for select_0, select_1, input_0, input_1, expected in test_vectors:
-                sim.set(dut.select_0, select_0)
-                sim.set(dut.select_1, select_1)
-                sim.set(dut.input_0, input_0)
-                sim.set(dut.input_1, input_1)
-                sim.set(dut.default, OneHotMuxEnum.ZERO)
-                await sim.tick()
-                assert sim.get(dut.output) == expected
+                assert got == expected
 
         with self.run_simulation(dut) as sim:
             sim.add_testbench(proc)

--- a/test/utils/test_amaranth_ext.py
+++ b/test/utils/test_amaranth_ext.py
@@ -58,7 +58,6 @@ class OneHotMuxDUT(Elaboratable):
         self.output = Signal(shape)  # type: ignore
         self.default = Signal(shape) if has_default else None  # type: ignore
         self.is_priority = is_priority
-        self.has_default = has_default
 
     def elaborate(self, platform):
         m = Module()
@@ -66,7 +65,7 @@ class OneHotMuxDUT(Elaboratable):
             OneHotMux.create(
                 m,
                 list(zip(self.select, self.inputs)),
-                self.default if self.has_default else None,
+                self.default,
                 priority=self.is_priority,
             )
         )

--- a/test/utils/test_amaranth_ext.py
+++ b/test/utils/test_amaranth_ext.py
@@ -1,8 +1,11 @@
+from amaranth import ValueCastable
+
 from transactron.testing import *
 import random
 import pytest
 from amaranth import *
-from transactron.utils.amaranth_ext import MultiPriorityEncoder, RingMultiPriorityEncoder
+from amaranth.lib.enum import Enum
+from transactron.utils.amaranth_ext import MultiPriorityEncoder, OneHotMux, RingMultiPriorityEncoder
 
 
 def get_expected_multi(input_width, output_count, input, *args):
@@ -26,6 +29,101 @@ def get_expected_ring(input_width, output_count, input, first, last):
         input //= 2
     places += [None] * output_count
     return places
+
+
+class OneHotMuxEnum(Enum, shape=1):
+    ZERO = 0
+    ONE = 1
+
+
+class TestOneHotMux(TestCaseWithSimulator):
+    def test_values(self):
+        class DUT(Elaboratable):
+            def __init__(self):
+                self.select_0 = Signal()
+                self.select_1 = Signal()
+                self.input_0 = Signal(2)
+                self.input_1 = Signal(2)
+                self.default = Const(3, 2)
+                self.output = Signal(2)
+
+            def elaborate(self, platform):
+                m = Module()
+                m.d.comb += self.output.eq(
+                    OneHotMux.create(
+                        m,
+                        [(self.select_0, self.input_0), (self.select_1, self.input_1)],
+                        self.default,
+                    )
+                )
+                return m
+
+        dut = DUT()
+
+        async def proc(sim: TestbenchContext):
+            test_vectors = [
+                (0, 0, 1, 2, 3),
+                (1, 0, 1, 2, 1),
+                (0, 1, 1, 2, 2),
+            ]
+            for select_0, select_1, input_0, input_1, expected in test_vectors:
+                sim.set(dut.select_0, select_0)
+                sim.set(dut.select_1, select_1)
+                sim.set(dut.input_0, input_0)
+                sim.set(dut.input_1, input_1)
+                await sim.tick()
+                assert sim.get(dut.output) == expected
+
+        with self.run_simulation(dut) as sim:
+            sim.add_testbench(proc)
+
+    def test_valuecastables(self):
+        class DUT(Elaboratable):
+            select_0: Value
+            select_1: Value
+            input_0: ValueCastable
+            input_1: ValueCastable
+            default: ValueCastable
+            output: ValueCastable
+
+            def __init__(self):
+                self.select_0 = Signal()
+                self.select_1 = Signal()
+                self.input_0 = Signal(OneHotMuxEnum)  # type: ignore
+                self.input_1 = Signal(OneHotMuxEnum)  # type: ignore
+                self.default = Signal(OneHotMuxEnum)  # type: ignore
+                self.output = Signal(OneHotMuxEnum)  # type: ignore
+
+            def elaborate(self, platform):
+                m = Module()
+                m.d.comb += Value.cast(self.output).eq(
+                    OneHotMux.create(
+                        m,
+                        [(self.select_0, self.input_0), (self.select_1, self.input_1)],
+                        self.default,
+                    )
+                )
+                return m
+
+        dut = DUT()
+
+        async def proc(sim: TestbenchContext):
+            test_vectors = [
+                (0, 0, OneHotMuxEnum.ZERO, OneHotMuxEnum.ONE, OneHotMuxEnum.ZERO),
+                (1, 0, OneHotMuxEnum.ZERO, OneHotMuxEnum.ONE, OneHotMuxEnum.ZERO),
+                (0, 1, OneHotMuxEnum.ZERO, OneHotMuxEnum.ONE, OneHotMuxEnum.ONE),
+            ]
+            for select_0, select_1, input_0, input_1, expected in test_vectors:
+                sim.set(dut.select_0, select_0)
+                sim.set(dut.select_1, select_1)
+                sim.set(dut.input_0, input_0)
+                sim.set(dut.input_1, input_1)
+                sim.set(dut.default, OneHotMuxEnum.ZERO)
+                await sim.tick()
+                assert sim.get(dut.output) == expected.value
+
+        with self.run_simulation(dut) as sim:
+            sim.add_testbench(proc)
 
 
 @pytest.mark.parametrize(

--- a/test/utils/test_amaranth_ext.py
+++ b/test/utils/test_amaranth_ext.py
@@ -120,7 +120,7 @@ class TestOneHotMux(TestCaseWithSimulator):
                 sim.set(dut.input_1, input_1)
                 sim.set(dut.default, OneHotMuxEnum.ZERO)
                 await sim.tick()
-                assert sim.get(dut.output) == expected.value
+                assert sim.get(dut.output) == expected
 
         with self.run_simulation(dut) as sim:
             sim.add_testbench(proc)

--- a/transactron/core/body.py
+++ b/transactron/core/body.py
@@ -9,9 +9,9 @@ from transactron.core.tmodule import CtrlPath, TModule
 from transactron.core.transaction_base import TransactionBase
 
 from amaranth import *
-from amaranth_types import ValueLike, SrcLoc
+from amaranth_types import ShapeLike, ValueLike, SrcLoc
 from typing import TYPE_CHECKING, ClassVar, NewType, NotRequired, Optional, Callable, TypedDict, Unpack, final
-from transactron.utils.amaranth_ext.elaboratables import OneHotSwitchDynamic
+from transactron.utils.amaranth_ext.functions import one_hot_mux
 from transactron.utils.assign import AssignArg
 from transactron.utils.transactron_helpers import from_method_layout, method_def_helper
 from transactron.utils.typing import MethodStruct
@@ -62,7 +62,7 @@ class Body(TransactionBase["Body"]):
         self.data_in: MethodStruct = Signal(from_method_layout(i), name=self.owned_name + "_data_in")
         self.data_out: MethodStruct = Signal(from_method_layout(o), name=self.owned_name + "_data_out")
         self.combiner: Callable[[Module, Sequence[MethodStruct], Value], AssignArg] = (
-            kwargs["combiner"] if "combiner" in kwargs else Body._default_combiner
+            kwargs["combiner"] if "combiner" in kwargs else Body._default_combiner(from_method_layout(i))
         )
         self.nonexclusive = kwargs["nonexclusive"] if "nonexclusive" in kwargs else False
         self.single_caller = kwargs["single_caller"] if "single_caller" in kwargs else False
@@ -117,14 +117,13 @@ class Body(TransactionBase["Body"]):
         return Body.stack[-1]
 
     @staticmethod
-    def _default_combiner(m: Module, args: Sequence[MethodStruct], runs: Value) -> AssignArg:
-        if len(args) == 1:
-            return args[0]
-        else:
-            ret = Signal.like(args[0])
-            for k in OneHotSwitchDynamic(m, runs):
-                m.d.comb += ret.eq(args[k])
-            return ret
+    def _default_combiner(shape: ShapeLike):
+        def impl(m: Module, args: Sequence[MethodStruct], runs: Value) -> AssignArg:
+            arg = Signal(shape)
+            m.d.comb += arg.eq(one_hot_mux(runs, [Value.cast(arg) for arg in args], assert_one_hot=False))
+            return arg
+
+        return impl
 
 
 TBody = NewType("TBody", Body)

--- a/transactron/core/body.py
+++ b/transactron/core/body.py
@@ -120,7 +120,7 @@ class Body(TransactionBase["Body"]):
     def _default_combiner(shape: ShapeLike):
         def impl(m: Module, args: Sequence[MethodStruct], runs: Value) -> AssignArg:
             arg = Signal(shape)
-            m.d.comb += arg.eq(one_hot_mux(runs, [Value.cast(arg) for arg in args], assert_one_hot=False))
+            m.d.comb += arg.eq(one_hot_mux(runs, args, assert_one_hot=False))
             return arg
 
         return impl

--- a/transactron/core/manager.py
+++ b/transactron/core/manager.py
@@ -500,7 +500,7 @@ class TransactionManager(Elaboratable):
             def validate_args_for_method(method: MBody):
                 calls = method_map.info_by_call[(transaction, method)]
                 runs = Cat(call.enable for call in calls)
-                combined = one_hot_mux(runs, [Value.cast(call.arg) for call in calls], assert_one_hot=False)
+                combined = one_hot_mux(runs, [call.arg for call in calls], assert_one_hot=False)
                 return method._validate_arguments(runs.any(), method.data_in.shape()(combined))
 
             runnable_terms = [

--- a/transactron/core/manager.py
+++ b/transactron/core/manager.py
@@ -499,18 +499,9 @@ class TransactionManager(Elaboratable):
 
             def validate_args_for_method(method: MBody):
                 calls = method_map.info_by_call[(transaction, method)]
-                arg_rec = Signal.like(method.data_in)
-                en = Signal()
-
-                m.d.comb += en.eq(Cat(call.enable for call in calls).any())
-                if len(calls) == 1:
-                    m.d.comb += arg_rec.eq(calls[0].arg)
-                else:
-                    # Only one call can be active per method and transaction due to call-path exclusivity.
-                    for i in OneHotSwitchDynamic(m, Cat(call.enable for call in calls)):
-                        m.d.comb += arg_rec.eq(calls[i].arg)
-
-                return method._validate_arguments(en, arg_rec)
+                runs = Cat(call.enable for call in calls)
+                combined = one_hot_mux(runs, [Value.cast(call.arg) for call in calls], assert_one_hot=False)
+                return method._validate_arguments(runs.any(), method.data_in.shape()(combined))
 
             runnable_terms = [
                 validate_args_for_method(method) for method in method_map.methods_by_transaction[transaction]

--- a/transactron/lib/transformers.py
+++ b/transactron/lib/transformers.py
@@ -530,7 +530,7 @@ class NonexclusiveWrapper(Elaboratable, TransformerOneTarget):
     def elaborate(self, platform):
         m = TModule()
 
-        @def_method(m, self.method, nonexclusive=True, combiner=Body._default_combiner)
+        @def_method(m, self.method, nonexclusive=True, combiner=Body._default_combiner(self.target.layout_in))
         def _(arg):
             return self.target(m, arg)
 

--- a/transactron/utils/amaranth_ext/elaboratables.py
+++ b/transactron/utils/amaranth_ext/elaboratables.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager
 from typing import Literal, Optional, overload
 from collections.abc import Iterable
 from amaranth import *
+from amaranth import ValueCastable
 from amaranth.lib.data import ArrayLayout, View
 from amaranth_types import HasElaborate, ShapeLike, ModuleLike, ValueLike
 
@@ -627,12 +628,12 @@ class OneHotMux(Elaboratable):
     Selection signal. When one of the select bits is set, the corresponding input is assigned to `output`.
     """
 
-    default_input: Value
+    default_input: ValueCastable
     """
     Default input signal. Only present if `has_default` is True.
     """
 
-    output: Value
+    output: ValueCastable
     """
     Output signal. It is set to `default_input` or one of `inputs` depending on `select`.
     """
@@ -655,8 +656,8 @@ class OneHotMux(Elaboratable):
         self.inputs = Signal(ArrayLayout(shape, inputs_count))
         self.select = Signal(inputs_count)
         if has_default:
-            self.default_input = Signal(shape)
-        self.output = Signal(shape)
+            self.default_input = Signal(shape)  # type: ignore
+        self.output = Signal(shape)  # type: ignore
 
         self.shape = Shape.cast(shape)
         self.priority = priority
@@ -699,7 +700,7 @@ class OneHotMux(Elaboratable):
         if default_input is not None:
             m.d.comb += Value.cast(fw_net.default_input).eq(default_input)
         for i, (sel_bit, input) in enumerate(inputs):
-            m.d.comb += fw_net.select[i].eq(sel_bit)
+            m.d.comb += fw_net.select[i].eq(Value.cast(sel_bit).any())
             m.d.comb += Value.cast(fw_net.inputs[i]).eq(input)
         return fw_net.output
 
@@ -709,7 +710,7 @@ class OneHotMux(Elaboratable):
         m.d.comb += Value.cast(self.output).eq(
             one_hot_mux(
                 self.select,
-                [self.inputs[i] for i in range(len(self.inputs))],
+                [field for (_, field) in self.inputs],
                 default=self.default_input if self.has_default else None,
                 priority=self.priority,
                 assert_one_hot=False,

--- a/transactron/utils/amaranth_ext/elaboratables.py
+++ b/transactron/utils/amaranth_ext/elaboratables.py
@@ -715,6 +715,7 @@ class OneHotMux(Elaboratable):
                     [self.inputs[i] for i in range(len(self.inputs))],
                     default=self.default_input if self.has_default else None,
                     priority=self.priority,
+                    assert_one_hot=False,
                 )
             )
         elif self.has_default:

--- a/transactron/utils/amaranth_ext/elaboratables.py
+++ b/transactron/utils/amaranth_ext/elaboratables.py
@@ -4,8 +4,10 @@ from typing import Literal, Optional, overload
 from collections.abc import Iterable
 from amaranth import *
 from amaranth import ValueCastable
-from amaranth.lib.data import ArrayLayout
+from amaranth.lib.data import ArrayLayout, View
 from amaranth_types import HasElaborate, ShapeLike, ModuleLike, ValueLike
+
+from transactron.utils.amaranth_ext.functions import one_hot_mux
 
 __all__ = [
     "OneHotSwitchDynamic",
@@ -615,51 +617,89 @@ class StableSelectingNetwork(Elaboratable):
 class OneHotMux(Elaboratable):
     """One-hot multiplexer.
 
-    If all select bits are 0, the `output` signal is set to `default_input`.
-    In the other case, the `output` signal is set to the input which
-    select bit is set. It is assumed that at most one `select` bit is set.
-
-    Attributes
+    Parameters
     ----------
-    inputs: Signal(ArrayLayout(shape, inputs_count)), in
-        Input signals.
-    select: Signal(inputs_count), in
-        Selection signal. When one of the select bits is set,
-        the corresponding input is assigned to `output`.
-    default_input: Signal(shape), in
-        Default input signal.
-    output: Signal(shape), out
-        Output signal. It is set to `default_input` or one of `inputs`
-        depending on `select`.
+    shape: ShapeLike
+         Shape of the inputs and output.
+    inputs_count: int
+        Number of inputs to select from.
+    priority: bool
+        If True do not assume that the select bits are one-hot, but choose the lowest on bit.
+    has_default: bool
+        Whether the multiplexer has a default input. If True, the output will be set to the default
+        input when all select bits are 0. If False, the output is zero when inputs_count > 1,
+        the only value if inputs_count == 1 and 0 vector if inputs_count == 0.
     """
 
-    def __init__(self, shape: ShapeLike, inputs_count: int):
+    inputs: View
+    """
+    Input signals.
+    """
+
+    select: Value
+    """
+    Selection signal. When one of the select bits is set, the corresponding input is assigned to `output`.
+    """
+
+    default_input: Value
+    """
+    Default input signal. Only present if `has_default` is True.
+    """
+
+    output: Value
+    """
+    Output signal. It is set to `default_input` or one of `inputs` depending on `select`.
+    """
+
+    def __init__(self, shape: ShapeLike, inputs_count: int, priority: bool = False, has_default: bool = True):
         self.inputs = Signal(ArrayLayout(shape, inputs_count))
         self.select = Signal(inputs_count)
-        self.default_input = Signal(shape)
+        if has_default:
+            self.default_input = Signal(shape)
         self.output = Signal(shape)
 
+        self.shape = Shape.cast(shape)
+        self.priority = priority
+        self.has_default = has_default
+
     @staticmethod
-    def create(m: ModuleLike, inputs: Iterable[tuple[ValueLike, ValueLike]], default_input: ValueLike) -> ValueLike:
+    def create(
+        m: ModuleLike,
+        inputs: Iterable[tuple[ValueLike, ValueLike]],
+        default_input: Optional[ValueLike] = None,
+        priority: bool = False,
+    ) -> ValueLike:
         """Syntax sugar for creating a `OneHotMux`.
 
         Parameters
         ----------
         m: Module
             Module to add the `OneHotMux` to.
-        default_input: ValueLike
-            Default input.
-        forward_inputs: Iterable[tuple[ValueLike, ValueLike]]
+        inputs: Iterable[tuple[ValueLike, ValueLike]]
             Select bits and corresponding inputs.
+        default_input: ValueLike, optional
+            Default input. If not provided, the multiplexer will set the output to 0 vector when all select bits are 0.
+        priority: bool
+            If True do not assume that the select bits are one-hot, but choose the lowest on bit.
         """
+        inputs = list(inputs)
+
         if isinstance(default_input, ValueCastable):
             input_shape = default_input.shape()
-        else:
+        elif default_input is not None:
             input_shape = Value.cast(default_input).shape()
-        inputs = list(inputs)
-        fw_net = OneHotMux(input_shape, len(inputs))
+        elif len(inputs) > 0:
+            input_shape = Value.cast(inputs[0][1]).shape()
+        else:
+            raise ValueError(
+                "Can not infer the shape of the inputs for OneHotMux,"
+                + "because no inputs were provided and default input was not provided as well."
+            )
+
+        fw_net = OneHotMux(input_shape, len(inputs), priority=priority, has_default=default_input is not None)
         m.submodules += fw_net
-        m.d.comb += Value.cast(fw_net.default_input).eq(default_input)
+        if default_input is not None:
+            m.d.comb += Value.cast(fw_net.default_input).eq(default_input)
         for i, (sel_bit, input) in enumerate(inputs):
             m.d.comb += fw_net.select[i].eq(sel_bit)
             m.d.comb += Value.cast(fw_net.inputs[i]).eq(input)
@@ -668,10 +708,16 @@ class OneHotMux(Elaboratable):
     def elaborate(self, platform):
         m = Module()
 
-        for i in OneHotSwitchDynamic(m, self.select, default=True):
-            if i is None:
-                m.d.comb += Value.cast(self.output).eq(self.default_input)
-            else:
-                m.d.comb += Value.cast(self.output).eq(self.inputs[i])
+        if len(self.inputs) > 0:
+            m.d.comb += self.output.eq(
+                one_hot_mux(
+                    self.select,
+                    [self.inputs[i] for i in range(len(self.inputs))],
+                    default=self.default_input if self.has_default else None,
+                    priority=self.priority,
+                )
+            )
+        elif self.has_default:
+            m.d.comb += self.output.eq(Value.cast(self.default_input))
 
         return m

--- a/transactron/utils/amaranth_ext/elaboratables.py
+++ b/transactron/utils/amaranth_ext/elaboratables.py
@@ -710,7 +710,7 @@ class OneHotMux(Elaboratable):
         m.d.comb += Value.cast(self.output).eq(
             one_hot_mux(
                 self.select,
-                [field for (_, field) in self.inputs],
+                [self.inputs[i] for i in range(len(self.select))],
                 default=self.default_input if self.has_default else None,
                 priority=self.priority,
                 assert_one_hot=False,

--- a/transactron/utils/amaranth_ext/elaboratables.py
+++ b/transactron/utils/amaranth_ext/elaboratables.py
@@ -3,11 +3,10 @@ from contextlib import contextmanager
 from typing import Literal, Optional, overload
 from collections.abc import Iterable
 from amaranth import *
-from amaranth import ValueCastable
 from amaranth.lib.data import ArrayLayout, View
 from amaranth_types import HasElaborate, ShapeLike, ModuleLike, ValueLike
 
-from transactron.utils.amaranth_ext.functions import one_hot_mux
+from transactron.utils.amaranth_ext.functions import one_hot_mux, shape_of
 
 __all__ = [
     "OneHotSwitchDynamic",
@@ -18,6 +17,7 @@ __all__ = [
     "MultiPriorityEncoder",
     "RingMultiPriorityEncoder",
     "StableSelectingNetwork",
+    "OneHotMux",
 ]
 
 
@@ -615,21 +615,7 @@ class StableSelectingNetwork(Elaboratable):
 
 
 class OneHotMux(Elaboratable):
-    """One-hot multiplexer.
-
-    Parameters
-    ----------
-    shape: ShapeLike
-         Shape of the inputs and output.
-    inputs_count: int
-        Number of inputs to select from.
-    priority: bool
-        If True do not assume that the select bits are one-hot, but choose the lowest on bit.
-    has_default: bool
-        Whether the multiplexer has a default input. If True, the output will be set to the default
-        input when all select bits are 0. If False, the output is zero when inputs_count > 1,
-        the only value if inputs_count == 1 and 0 vector if inputs_count == 0.
-    """
+    """One-hot multiplexer."""
 
     inputs: View
     """
@@ -652,6 +638,20 @@ class OneHotMux(Elaboratable):
     """
 
     def __init__(self, shape: ShapeLike, inputs_count: int, priority: bool = False, has_default: bool = True):
+        """Parameters
+        ----------
+        shape: ShapeLike
+            Shape of the inputs and output.
+        inputs_count: int
+            Number of inputs to select from.
+        priority: bool
+            If True do not assume that the select bits are one-hot, but choose the lowest on bit.
+        has_default: bool
+            Whether the multiplexer has a default input. If True, the output will be set to the default
+            input when all select bits are 0. If False, the output is zero when inputs_count > 1,
+            the only value if inputs_count == 1 and 0 vector if inputs_count == 0.
+        """
+
         self.inputs = Signal(ArrayLayout(shape, inputs_count))
         self.select = Signal(inputs_count)
         if has_default:
@@ -684,12 +684,10 @@ class OneHotMux(Elaboratable):
         """
         inputs = list(inputs)
 
-        if isinstance(default_input, ValueCastable):
-            input_shape = default_input.shape()
-        elif default_input is not None:
-            input_shape = Value.cast(default_input).shape()
+        if default_input is not None:
+            input_shape = shape_of(default_input)
         elif len(inputs) > 0:
-            input_shape = Value.cast(inputs[0][1]).shape()
+            input_shape = shape_of(inputs[0][1])
         else:
             raise ValueError(
                 "Can not infer the shape of the inputs for OneHotMux,"
@@ -708,17 +706,14 @@ class OneHotMux(Elaboratable):
     def elaborate(self, platform):
         m = Module()
 
-        if len(self.inputs) > 0:
-            m.d.comb += self.output.eq(
-                one_hot_mux(
-                    self.select,
-                    [self.inputs[i] for i in range(len(self.inputs))],
-                    default=self.default_input if self.has_default else None,
-                    priority=self.priority,
-                    assert_one_hot=False,
-                )
+        m.d.comb += Value.cast(self.output).eq(
+            one_hot_mux(
+                self.select,
+                [self.inputs[i] for i in range(len(self.inputs))],
+                default=self.default_input if self.has_default else None,
+                priority=self.priority,
+                assert_one_hot=False,
             )
-        elif self.has_default:
-            m.d.comb += self.output.eq(Value.cast(self.default_input))
+        )
 
         return m

--- a/transactron/utils/amaranth_ext/functions.py
+++ b/transactron/utils/amaranth_ext/functions.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Optional
 from amaranth import *
 from amaranth.hdl import ShapeCastable, ValueCastable
 from amaranth.hdl._ast import SwitchValue
@@ -9,6 +9,7 @@ import operator
 
 from amaranth_types.types import ValueLike, ShapeLike
 from transactron.utils.typing import ValueBundle
+from transactron.utils.logging import top_assertion
 
 __all__ = [
     "mod_incr",
@@ -27,6 +28,7 @@ __all__ = [
     "generic_min_value",
     "min_value",
     "max_value",
+    "one_hot_mux",
 ]
 
 
@@ -193,3 +195,64 @@ def min_value(*values: ValueBundle) -> Value:
 
 def max_value(*values: ValueBundle) -> Value:
     return generic_min_value(*values, operator=operator.gt)
+
+
+def one_hot_mux(
+    select: ValueLike,
+    inputs: list[ValueLike],
+    default: Optional[ValueLike] = None,
+    priority: bool = False,
+    assert_one_hot: bool = True,
+) -> Value:
+    """
+    One-hot multiplexer.
+    Takes n input values and a one-hot select signal of n bits and outputs the value corresponding
+    to the bit set in the select signal.
+    If priority is False and multiple bits are set, the output is undefined.
+    If priority is True and multiple bits are set, the output corresponds to the lowest set bit in the select signal.
+    If assert_one_hot is True and priority is False, an assertion is added that checks
+    that the select signal is one-hot.
+    If default is provided and select signal is 0, the output is default,
+    otherwise select must have at least one bit set.
+    """
+    if default is not None:
+        shape = shape_of(default)
+    elif len(inputs) > 0:
+        shape = shape_of(inputs[0])
+    else:
+        raise ValueError("At least one input or default value must be provided")
+
+    if len(inputs) == 0:
+        return Value.cast(default) if default is not None else C(0, shape)
+
+    select = Value.cast(select).as_unsigned()
+
+    if default is None and assert_one_hot:
+        top_assertion(
+            select.any(),
+            "Select signal must be one-hot, but no bits are set",
+            src_loc=1,
+        )
+
+    if default is None and len(inputs) == 1:
+        return Value.cast(inputs[0])
+
+    select_first = select & (~select + 1)
+    select_one_hot = select_first if priority else select
+
+    if not priority and assert_one_hot:
+        top_assertion(
+            select == select_first,
+            "Select signal must be one-hot with priority=False, select: {:b}",
+            select,
+            src_loc=1,
+        )
+
+    value_combined = or_value([Mux(select_one_hot[i], Value.cast(inputs[i]), 0) for i in range(len(inputs))])
+
+    print(value_combined.shape())
+
+    if default is None:
+        return value_combined
+
+    return Mux(select.any(), value_combined, Value.cast(default))

--- a/transactron/utils/amaranth_ext/functions.py
+++ b/transactron/utils/amaranth_ext/functions.py
@@ -4,7 +4,7 @@ from amaranth.hdl import ShapeCastable, ValueCastable
 from amaranth.hdl._ast import SwitchValue
 from amaranth.utils import bits_for, ceil_log2
 from amaranth.lib import data
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping, Sequence
 import operator
 
 from amaranth_types.types import ValueLike, ShapeLike
@@ -199,7 +199,7 @@ def max_value(*values: ValueBundle) -> Value:
 
 def one_hot_mux(
     select: ValueLike,
-    inputs: list[ValueLike],
+    inputs: Sequence[ValueLike],
     default: Optional[ValueLike] = None,
     priority: bool = False,
     assert_one_hot: bool = True,
@@ -215,6 +215,8 @@ def one_hot_mux(
     If default is provided and select signal is 0, the output is default,
     otherwise select must have at least one bit set.
     """
+    inputs = list(inputs)
+
     if len(inputs) == 0:
         return Value.cast(default) if default is not None else C(0)
 

--- a/transactron/utils/amaranth_ext/functions.py
+++ b/transactron/utils/amaranth_ext/functions.py
@@ -215,15 +215,8 @@ def one_hot_mux(
     If default is provided and select signal is 0, the output is default,
     otherwise select must have at least one bit set.
     """
-    if default is not None:
-        shape = shape_of(default)
-    elif len(inputs) > 0:
-        shape = shape_of(inputs[0])
-    else:
-        raise ValueError("At least one input or default value must be provided")
-
     if len(inputs) == 0:
-        return Value.cast(default) if default is not None else C(0, shape)
+        return Value.cast(default) if default is not None else C(0)
 
     select = Value.cast(select).as_unsigned()
 
@@ -249,8 +242,6 @@ def one_hot_mux(
         )
 
     value_combined = or_value([Mux(select_one_hot[i], Value.cast(inputs[i]), 0) for i in range(len(inputs))])
-
-    print(value_combined.shape())
 
     if default is None:
         return value_combined

--- a/transactron/utils/logging.py
+++ b/transactron/utils/logging.py
@@ -10,7 +10,7 @@ from typing import TypeAlias
 from amaranth import *
 from amaranth_types import ModuleLike, ValueLike
 
-from transactron.utils import SrcLoc, get_src_loc, local_src_loc
+from transactron.utils.transactron_helpers import SrcLoc, get_src_loc, local_src_loc
 from transactron.utils.dependencies import DependencyContext, ListKey
 
 


### PR DESCRIPTION
OneHotMux, but better.

The codified design pattern used in a few places in amaranth. Also reduces critical path for `OneHotMux` instances