### PR TITLE
fix #171

### DIFF
--- a/test/lib/test_simultaneous.py
+++ b/test/lib/test_simultaneous.py
@@ -124,3 +124,42 @@ class TestUncalledMethod(TestCaseWithSimulator):
 
         with self.run_simulation(circ) as sim:
             sim.add_testbench(process)
+
+
+class NotRunningConditionCallingCircuit(Elaboratable):
+    def __init__(self):
+        self.sig = Signal()
+
+    def elaborate(self, platform):
+        m = TModule()
+
+        cond = Method()
+        called = Method()
+
+        @def_method(m, cond)
+        def _():
+            with condition(m) as branch:
+                with branch():
+                    called(m)
+
+        @def_method(m, called)
+        def _():
+            m.d.comb += self.sig.eq(1)
+
+        with Transaction().body(m):
+            with m.If(0):
+                cond(m)
+
+        return m
+
+
+class TestNotRunningConditionCalling(TestCaseWithSimulator):
+    def test_not_running_condition(self):
+        circ = NotRunningConditionCallingCircuit()
+
+        async def process(sim: TestbenchContext):
+            _, _, val = await sim.tick().sample(circ.sig)
+            assert val == 0
+
+        with self.run_simulation(circ) as sim:
+            sim.add_testbench(process)

--- a/transactron/core/manager.py
+++ b/transactron/core/manager.py
@@ -380,7 +380,7 @@ class TransactionManager(Elaboratable):
         for elem in method_map.methods_and_transactions:
             if elem.simultaneous_list and elem in conditionally_called_methods:
                 # nested definitions do not trigger the issue
-                if any(not elem.ctrl_path.is_proper_prefix(sim_elem.ctrl_path) for sim_elem in elem.simultaneous_list):
+                if any(elem not in ready_dependencies[sim_elem] for sim_elem in elem.simultaneous_list):
                     raise RuntimeError(
                         "Simultaneity constraint for conditionally called method "
                         f"'{elem.name}' {elem.src_loc} not supported"

--- a/transactron/core/manager.py
+++ b/transactron/core/manager.py
@@ -343,6 +343,7 @@ class TransactionManager(Elaboratable):
 
     def _simultaneous(self):
         method_map = MethodMap(self.transactions, self.methods)
+        ready_dependencies = TransactionManager._ready_dependencies(self.transactions, self.methods)
 
         # remove orderings between simultaneous methods/transactions
         # TODO: can it be done after transitivity, possibly catching more cases?
@@ -439,7 +440,9 @@ class TransactionManager(Elaboratable):
                 name = "_".join([t.name for t in group])
                 with Transaction(name=name).body(m):
                     for transaction in group:
-                        methods[transaction](m)
+                        methods[transaction](
+                            m, enable_call=Cat(dep.run for dep in ready_dependencies[transaction]).all()
+                        )
             self.transactions += DependencyContext.get().get_dependency(TransactionsKey())
 
         return m


### PR DESCRIPTION
Turns out this was really related to #105, but not directly (the simultaneous transactions that were simultaneous with a method do not get the `run` signal masked by the `run` of the method) - it surfaced when the run signal got actually set via top_comb from the body, as before the ready signal of the inner transaction was silently masked by the assignment in the standard comb domain.

On the other note I think the simultaneous relations can be thought of (are the same as?) bidirectional ready dependency or when having independence sets - a generalised ready dependency with a "only one running in a set" semantics. I think using this #105 could be solved.