### PR TITLE
Clear method maintenance

### DIFF
--- a/transactron/lib/allocators.py
+++ b/transactron/lib/allocators.py
@@ -284,7 +284,7 @@ class CircularAllocator(Elaboratable):
                 "new_start_idx": new_start_idx,
             }
 
-        @def_method(m, self.clear)
+        @def_method(m, self.clear, nonexclusive=True)
         def _():
             m.d.sync += self.start_idx.eq(0)
             m.d.sync += self.end_idx.eq(0)

--- a/transactron/lib/allocators.py
+++ b/transactron/lib/allocators.py
@@ -284,7 +284,7 @@ class CircularAllocator(Elaboratable):
                 "new_start_idx": new_start_idx,
             }
 
-        @def_method(m, self.clear, nonexclusive=True)
+        @def_method(m, self.clear)
         def _():
             m.d.sync += self.start_idx.eq(0)
             m.d.sync += self.end_idx.eq(0)

--- a/transactron/lib/connectors.py
+++ b/transactron/lib/connectors.py
@@ -151,7 +151,7 @@ class Forwarder(Elaboratable):
         def _():
             return read_value
 
-        @def_method(m, self.clear)
+        @def_method(m, self.clear, nonexclusive=True)
         def _():
             m.d.sync += reg_valid.eq(0)
 
@@ -221,7 +221,7 @@ class Pipe(Elaboratable):
             m.d.sync += reg.eq(arg)
             m.d.sync += reg_valid.eq(1)
 
-        @def_method(m, self.clear)
+        @def_method(m, self.clear, nonexclusive=True)
         def _():
             m.d.sync += reg_valid.eq(0)
 

--- a/transactron/lib/connectors.py
+++ b/transactron/lib/connectors.py
@@ -437,51 +437,63 @@ class CrossbarConnectTrans(Elaboratable):
 
 
 class Connector(HasElaborate, Protocol):
-    """Module used for connecting two methods.
+    """Module implementing fifo-ordered connector."""
 
-    Additional requirements:
-    - read and peek must have the same output layout as write's input layout
-    - read and peek's input layout and write's output layout be empty
-    - peek and read methods must not be in conflict
+    read: Method
+    """Reads from the connector.
 
-    Attributes
+    Parameters
     ----------
-    read: Method
-        The read method. Accepts an empty argument, returns a structure.
-    peek: Method, nonexclusive
-        Like `read`, but doesn't take the value from the connector.
-    write: Method
-        The write method. Accepts a structure, returns empty result.
-    """
+    m: TModule
+        Transactron module.
 
-    read: Method
+    Returns
+    -------
+    MethodStruct
+        Data with layout `write.layout_out`
+    """
     peek: Method
+    """Returns the element that would be output from `read`.
+
+    This method must not be in conflict with `read`.
+    This method must be nonexclusive.
+
+    Parameters
+    ----------
+    m: TModule
+        Transactron module.
+
+    Returns
+    -------
+    MethodStruct
+        Data with layout `write.layout_out`.
+    """
     write: Method
+    """Writes to the connector.
+
+    The values written via this method must show to the `read` and `peek` methods
+    in the same order as they were written.
+
+    Parameters
+    ----------
+    m: TModule
+        Transactron module.
+    **kwargs: ValueLike
+        Arguments as specified by the data layout.
+    """
 
 
 class ClearableConnector(Connector, Protocol):
-    """Connector with a clear support.
+    """Connector with a clear support."""
 
-    Other than requirements of `Connector`, also requires a `clear` method.
+    clear: Method
+    """Clears the connector.
 
-    The `clear` must:
-    - have an empty input and output layout
-    - actually clear the connector, i.e. no value from before `clear`
-    should be ever returned by `read` or `peek`.
-    - if `write` and `clear` were run in the same cycle, the value can be
-    returned by `read` or `peek` only in this cycle, otherwise it should
-    not be returned.
+    The connector must be empty the cycle after the clear regardless of the status to `write`.
+    Connector being empty means that all perviously written values should be considered consumed.
 
-    Attributes
+    Parameters
     ----------
-    read: Method
-        The read method. Accepts an empty argument, returns a structure.
-    peek: Method, nonexclusive
-        Like `read`, but doesn't take the value from the connector.
-    write: Method
-        The write method. Accepts a structure, returns empty result.
-    clear: Method
-        The clear method. Accepts an empty argument, returns empty result.
+    m: TModule
+        Transactron module.
     """
-
-    clear: Method

--- a/transactron/lib/connectors.py
+++ b/transactron/lib/connectors.py
@@ -123,10 +123,6 @@ class Forwarder(Elaboratable):
         self.write = Method(i=layout, src_loc=src_loc)
         self.clear = Method(src_loc=src_loc)
 
-        self.clear.add_conflict(self.read, Priority.LEFT)
-        self.clear.add_conflict(self.peek, Priority.LEFT)
-        self.clear.add_conflict(self.write, Priority.LEFT)
-
     def elaborate(self, platform):
         m = TModule()
 
@@ -201,10 +197,6 @@ class Pipe(Elaboratable):
         self.write = Method(i=layout, src_loc=src_loc)
         self.clear = Method()
         self.head = Signal.like(self.read.data_out)
-
-        self.clear.add_conflict(self.read, Priority.LEFT)
-        self.clear.add_conflict(self.peek, Priority.LEFT)
-        self.clear.add_conflict(self.write, Priority.LEFT)
 
     def elaborate(self, platform):
         m = TModule()
@@ -472,11 +464,13 @@ class ClearableConnector(Connector, Protocol):
 
     Other than requirements of `Connector`, also requires a `clear` method.
 
-    The `clear` method must be in conflict with all other methods of the connector, and have priority over them.
-    Furthermore `clear` must:
+    The `clear` must:
     - have an empty input and output layout
-    - actually clear the connector, i.e. no value from before or the same cycle as the `clear`
+    - actually clear the connector, i.e. no value from before `clear`
     should be ever returned by `read` or `peek`.
+    - if `write` and `clear` were run in the same cycle, the value can be
+    returned by `read` or `peek` only in this cycle, otherwise it should
+    not be returned.
 
     Attributes
     ----------

--- a/transactron/lib/connectors.py
+++ b/transactron/lib/connectors.py
@@ -489,7 +489,7 @@ class ClearableConnector(Connector, Protocol):
     clear: Method
     """Clears the connector.
 
-    The connector must be empty the cycle after the clear regardless of the status to `write`.
+    The connector must be empty the cycle after the clear regardless of `write` being run or not.
     Connector being empty means that all perviously written values should be considered consumed.
 
     Parameters

--- a/transactron/lib/connectors.py
+++ b/transactron/lib/connectors.py
@@ -151,7 +151,7 @@ class Forwarder(Elaboratable):
         def _():
             return read_value
 
-        @def_method(m, self.clear, nonexclusive=True)
+        @def_method(m, self.clear)
         def _():
             m.d.sync += reg_valid.eq(0)
 
@@ -221,7 +221,7 @@ class Pipe(Elaboratable):
             m.d.sync += reg.eq(arg)
             m.d.sync += reg_valid.eq(1)
 
-        @def_method(m, self.clear, nonexclusive=True)
+        @def_method(m, self.clear)
         def _():
             m.d.sync += reg_valid.eq(0)
 

--- a/transactron/lib/connectors.py
+++ b/transactron/lib/connectors.py
@@ -450,7 +450,7 @@ class Connector(HasElaborate, Protocol):
     Returns
     -------
     MethodStruct
-        Data with layout `write.layout_out`
+        Data with layout `write.layout_in`
     """
     peek: Method
     """Returns the element that would be output from `read`.
@@ -466,7 +466,7 @@ class Connector(HasElaborate, Protocol):
     Returns
     -------
     MethodStruct
-        Data with layout `write.layout_out`.
+        Data with layout `write.layout_in`.
     """
     write: Method
     """Writes to the connector.
@@ -479,7 +479,7 @@ class Connector(HasElaborate, Protocol):
     m: TModule
         Transactron module.
     **kwargs: ValueLike
-        Arguments as specified by the data layout.
+        Arguments as specified by the layout.
     """
 
 

--- a/transactron/lib/fifo.py
+++ b/transactron/lib/fifo.py
@@ -139,7 +139,7 @@ class BasicFifo(Elaboratable):
         def _() -> ValueLike:
             return self.head
 
-        @def_method(m, self.clear)
+        @def_method(m, self.clear, nonexclusive=True)
         def _() -> None:
             allocator.clear(m)
 
@@ -334,7 +334,7 @@ class WideFifo(Elaboratable):
         def _():
             return {"count": read_available, "data": head}
 
-        @def_method(m, self.clear)
+        @def_method(m, self.clear, nonexclusive=True)
         def _() -> None:
             m.d.sync += write_idx.eq(0)
             m.d.sync += read_idx.eq(0)
@@ -387,7 +387,7 @@ class Semaphore(Elaboratable):
         def _() -> None:
             pass
 
-        @def_method(m, self.clear)
+        @def_method(m, self.clear, nonexclusive=True)
         def _() -> None:
             pass
 

--- a/transactron/lib/fifo.py
+++ b/transactron/lib/fifo.py
@@ -139,7 +139,7 @@ class BasicFifo(Elaboratable):
         def _() -> ValueLike:
             return self.head
 
-        @def_method(m, self.clear, nonexclusive=True)
+        @def_method(m, self.clear)
         def _() -> None:
             allocator.clear(m)
 
@@ -334,7 +334,7 @@ class WideFifo(Elaboratable):
         def _():
             return {"count": read_available, "data": head}
 
-        @def_method(m, self.clear, nonexclusive=True)
+        @def_method(m, self.clear)
         def _() -> None:
             m.d.sync += write_idx.eq(0)
             m.d.sync += read_idx.eq(0)
@@ -387,7 +387,7 @@ class Semaphore(Elaboratable):
         def _() -> None:
             pass
 
-        @def_method(m, self.clear, nonexclusive=True)
+        @def_method(m, self.clear)
         def _() -> None:
             pass
 

--- a/transactron/lib/fifo.py
+++ b/transactron/lib/fifo.py
@@ -3,7 +3,7 @@ from amaranth import *
 import amaranth.lib.memory as memory
 import amaranth.lib.data as data
 from amaranth_types import ShapeLike, ValueLike, SrcLoc
-from transactron import Method, def_method, Priority, TModule
+from transactron import Method, def_method, TModule
 from transactron.lib.allocators import CircularAllocator
 from transactron.utils.typing import MethodLayout, MethodStruct
 from transactron.utils.amaranth_ext import mod_incr, rotate_vec_right, rotate_vec_left
@@ -365,9 +365,6 @@ class Semaphore(Elaboratable):
 
         self.count = Signal(range(self.max_count + 1))
         self.count_next = Signal(range(self.max_count + 1))
-
-        self.clear.add_conflict(self.acquire, Priority.LEFT)
-        self.clear.add_conflict(self.release, Priority.LEFT)
 
     def elaborate(self, platform) -> TModule:
         m = TModule()

--- a/transactron/lib/pipeline.py
+++ b/transactron/lib/pipeline.py
@@ -526,7 +526,7 @@ class PipelineBuilder(Elaboratable):
 
             clear_methods.append(fwd.clear)
 
-        @def_method(m, self.clear)
+        @def_method(m, self.clear, nonexclusive=True)
         def _():
             for clear_method in clear_methods:
                 _ = clear_method(m)

--- a/transactron/lib/pipeline.py
+++ b/transactron/lib/pipeline.py
@@ -526,7 +526,7 @@ class PipelineBuilder(Elaboratable):
 
             clear_methods.append(fwd.clear)
 
-        @def_method(m, self.clear, nonexclusive=True)
+        @def_method(m, self.clear)
         def _():
             for clear_method in clear_methods:
                 _ = clear_method(m)

--- a/transactron/lib/stack.py
+++ b/transactron/lib/stack.py
@@ -145,7 +145,7 @@ class Stack(Elaboratable):
         def _() -> ValueLike:
             return self.head
 
-        @def_method(m, self.clear, nonexclusive=True)
+        @def_method(m, self.clear)
         def _() -> None:
             pass  # size change handled in earlier code
 

--- a/transactron/lib/stack.py
+++ b/transactron/lib/stack.py
@@ -145,7 +145,7 @@ class Stack(Elaboratable):
         def _() -> ValueLike:
             return self.head
 
-        @def_method(m, self.clear)
+        @def_method(m, self.clear, nonexclusive=True)
         def _() -> None:
             pass  # size change handled in earlier code
 


### PR DESCRIPTION
Some observations:
- all connectors have either `write` > `read` > `clear` or `read` > `write` > `clear` semantics (where the first one is only seen in `Forwarder`) - I have codified this in the docs of the `ClearableConnector` - specifically the requirements on `clear`
- the semantics would hold well with nonexclusive `clear` (can be just done with `find ./transactron -name '*.py' -type f -exec sed -Ei 's/@def_method\(m, self\.clear\)/@def_method(m, self.clear, nonexclusive=True)/' {} \;`
- maybe it would be nice to have automatic way to generate `peak`-like nonexclusive methods from methods that do not have any inputs

This also removes the `clear` conflict from `Semaphore` - the same semantics as `BasicFifo` with empty layout (maybe it should be implemented as such)