### PR TITLE
Structured hardware event log (evlog)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ venv.bak/
 
 # Tests outputs
 test/__traces__
+test/__evlogs__
 test/__profiles__/*.json
 pytestdebug.log
 .hypothesis

--- a/docs/evlog.md
+++ b/docs/evlog.md
@@ -1,12 +1,12 @@
 # Event log
 
-The `transactron.evlog` package instruments a hardware design with structured, typed events which are captured during simulation into an *event log*. Event logs are consumed by downstream tools - pipeline trace converters, statistics scripts, checkers - without touching the hardware description again.
+The {py:mod}`transactron.evlog` package instruments a hardware design with structured, typed events which are captured during simulation into an *event log*. Event logs are consumed by downstream tools - pipeline trace converters, statistics scripts, checkers - without touching the hardware description again.
 
 The event log carries machine-readable payloads: named, typed fields with a stable schema. The same captured log can be decoded offline, long after the simulation finished, as long as the schema (saved together with the log) and the event definitions are available.
 
 ## Defining events
 
-Events are dataclasses declared with the `event` decorator. The event name must be globally unique:
+Events are dataclasses declared with the {py:func}`~transactron.evlog.event.event` decorator. The event name must be globally unique:
 
 ```python
 from transactron.evlog import Event, Static, event
@@ -21,11 +21,11 @@ class ExecUnitStart(Event):
 There are two kinds of fields:
 
 - **dynamic** fields are backed by hardware signals, sampled in every cycle in which the event fires. Annotate them with the *decoded* Python type: `int`, `bool` or an `enum.Enum` subclass (raw integers are converted back to the annotated type when a log is decoded). Signal widths are not declared - they are inferred from the actual Amaranth values at elaboration time and recorded in the schema, so parameterized designs need no special handling.
-- **static** fields (annotated with `Static[...]`) hold plain Python values fixed at elaboration time and cost no hardware. Use them for properties of the emission site, such as a lane index or a unit name.
+- **static** fields (annotated with {py:obj}`~transactron.evlog.event.Static`) hold plain Python values fixed at elaboration time and cost no hardware. Use them for properties of the emission site, such as a lane index or a unit name.
 
 ## Emitting events
 
-`EventSource` mirrors the `HardwareLogger` API. Since during elaboration the dynamic fields hold Amaranth values rather than their declared types, instances are constructed with the `Event.hw` classmethod:
+{py:class}`~transactron.evlog.emit.EventSource` mirrors the {py:class}`~transactron.utils.logging.HardwareLogger` API. Since during elaboration the dynamic fields hold Amaranth values rather than their declared types, instances are constructed with the {py:meth}`Event.hw <transactron.evlog.event.Event.hw>` classmethod:
 
 ```python
 from transactron.evlog import EventSource
@@ -37,9 +37,9 @@ def elaborate(self, platform):
     self.evlog.emit(m, ExecUnitStart.hw(insn_tag=tag, kind=kind, lane=0), when=start)
 ```
 
-The event fires in every cycle in which `when` is true and the surrounding module context (`m.If`, transaction or method body) is active. `top_emit` is available for contexts without a module. Emitting the same event type multiple times (e.g. once per superscalar lane, distinguished by a static field) creates separate emission sites.
+The event fires in every cycle in which `when` is true and the surrounding module context (`m.If`, transaction or method body) is active. {py:meth}`~transactron.evlog.emit.EventSource.top_emit` is available for contexts without a module. Emitting the same event type multiple times (e.g. once per superscalar lane, distinguished by a static field) creates separate emission sites.
 
-Event logging is disabled by default and `emit` is then a no-op, so instrumentation has no cost in synthesis flows. Enable it before elaboration with:
+Event logging is disabled by default and {py:meth}`~transactron.evlog.emit.EventSource.emit` is then a no-op, so instrumentation has no cost in synthesis flows. Enable it before elaboration with:
 
 ```python
 DependencyContext.get().add_dependency(EvLogEnabledKey(), True)
@@ -47,9 +47,9 @@ DependencyContext.get().add_dependency(EvLogEnabledKey(), True)
 
 ## Capturing events
 
-Every emission site registered during elaboration is described by an `EvLogSchema`: the event name, source name, dynamic field names and widths, and static field values. The schema is the only contract between the elaborated design and event log consumers.
+Every emission site registered during elaboration is described by an {py:class}`~transactron.evlog.schema.EvLogSchema`: the event name, source name, dynamic field names and widths, and static field values. The schema is the only contract between the elaborated design and event log consumers.
 
-With the Amaranth simulator, capture events with `transactron.testing.evlog`:
+With the Amaranth simulator, capture events with {py:func}`~transactron.testing.evlog.capture_evlog`:
 
 ```python
 from transactron.testing.evlog import capture_evlog
@@ -62,9 +62,9 @@ with self.run_simulation(m) as sim:
 events = log.decoded()      # or log.save("events.jsonl")
 ```
 
-Tests based on `TestCaseWithSimulator` capture event logs automatically when pytest is invoked with `--transactron-evlog`: every test which registered any emission sites (i.e. tests which enabled the event log themselves) saves its captured events to `test/__evlogs__/<test name>.jsonl`. The flag only controls capturing - enabling the event log stays a separate concern.
+Tests based on {py:class}`~transactron.testing.test_case.TestCaseWithSimulator` capture event logs automatically when pytest is invoked with `--transactron-evlog`: every test which registered any emission sites (i.e. tests which enabled the event log themselves) saves its captured events to `test/__evlogs__/<test name>.jsonl`. The flag only controls capturing - enabling the event log stays a separate concern.
 
-For generated Verilog, `generate_verilog` records the event log schema together with signal locations in `GenerationInfo.evlog`, including a packed vector of all event triggers so that a simulator only needs a single signal read per cycle to check all sites. `GeneratedEvLogSampler` samples events through any backend able to read signals by hierarchical location (e.g. cocotb on top of Verilator):
+For generated Verilog, {py:func}`~transactron.utils.gen.generate_verilog` records the event log schema together with signal locations in {py:attr}`GenerationInfo.evlog <transactron.utils.gen.GenerationInfo.evlog>`, including a packed vector of all event triggers so that a simulator only needs a single signal read per cycle to check all sites. {py:class}`~transactron.evlog.sampler.GeneratedEvLogSampler` samples events through any backend able to read signals by hierarchical location (e.g. cocotb on top of Verilator):
 
 ```python
 from transactron.evlog import EventLogWriter, GeneratedEvLogSampler
@@ -77,7 +77,7 @@ with EventLogWriter("events.jsonl", gen_info.evlog.schema) as writer:
 
 ## Event log files and consumers
 
-Event logs are stored as JSON lines: a header with the schema and free-form metadata, followed by one record per fired event. `EventLog.load` reads a log into memory; `EventLogReader` decodes it lazily for logs too large to hold in memory.
+Event logs are stored as JSON lines: a header with the schema and free-form metadata, followed by one record per fired event. {py:meth}`EventLog.load <transactron.evlog.log.EventLog.load>` reads a log into memory; {py:class}`~transactron.evlog.log.EventLogReader` decodes it lazily for logs too large to hold in memory.
 
 The `transactron-evlog` command pretty-prints event log files. It works from the schema alone; passing `-m <module>` imports the event definitions so that enum fields are printed as member names:
 
@@ -91,7 +91,7 @@ $ transactron-evlog -m coreblocks.telemetry -f "ftq" -c 8:10 events.jsonl
 
 `--schema` prints a summary of the emission sites instead; `-x`/`-d` force hex/decimal field values.
 
-Consumers subclass `EventConsumer` and declare one handler per event type; dispatch is keyed by the registered event name:
+Consumers subclass {py:class}`~transactron.evlog.consumer.EventConsumer` and declare one handler per event type with {py:func}`~transactron.evlog.consumer.handles`; dispatch is keyed by the registered event name:
 
 ```python
 from transactron.evlog import DecodedEvent, EventConsumer, EventLogReader, handles
@@ -104,4 +104,4 @@ class KonataConverter(EventConsumer):
 KonataConverter().run(EventLogReader("events.jsonl"))
 ```
 
-`EventConsumer.run` sorts records by cycle, so capture order does not matter - which is convenient for output formats requiring monotonic timestamps. Events without a handler go to `on_unhandled`; override it to detect drift between the schema and the consumer.
+{py:meth}`EventConsumer.run <transactron.evlog.consumer.EventConsumer.run>` sorts records by cycle, so capture order does not matter - which is convenient for output formats requiring monotonic timestamps. Events without a handler go to {py:meth}`~transactron.evlog.consumer.EventConsumer.on_unhandled`; override it to detect drift between the schema and the consumer.

--- a/docs/evlog.md
+++ b/docs/evlog.md
@@ -62,7 +62,7 @@ with self.run_simulation(m) as sim:
 events = log.decoded()      # or log.save("events.jsonl")
 ```
 
-Tests based on {py:class}`~transactron.testing.test_case.TestCaseWithSimulator` capture event logs automatically when pytest is invoked with `--transactron-evlog`: every test which registered any emission sites (i.e. tests which enabled the event log themselves) saves its captured events to `test/__evlogs__/<test name>.jsonl`. The flag only controls capturing - enabling the event log stays a separate concern.
+Tests based on {py:class}`~transactron.testing.test_case.TestCaseWithSimulator` capture event logs automatically when pytest is invoked with `__TRANSACTRON_EVLOG=1` in the environment: every test which registered any emission sites (i.e. tests which enabled the event log themselves) saves its captured events to `test/__evlogs__/<test name>.jsonl`. The flag only controls capturing - enabling the event log stays a separate concern.
 
 For generated Verilog, {py:func}`~transactron.utils.gen.generate_verilog` records the event log schema together with signal locations in {py:attr}`GenerationInfo.evlog <transactron.utils.gen.GenerationInfo.evlog>`, including a packed vector of all event triggers so that a simulator only needs a single signal read per cycle to check all sites. {py:class}`~transactron.evlog.sampler.GeneratedEvLogSampler` samples events through any backend able to read signals by hierarchical location (e.g. cocotb on top of Verilator):
 

--- a/docs/evlog.md
+++ b/docs/evlog.md
@@ -1,0 +1,107 @@
+# Event log
+
+The `transactron.evlog` package instruments a hardware design with structured, typed events which are captured during simulation into an *event log*. Event logs are consumed by downstream tools - pipeline trace converters, statistics scripts, checkers - without touching the hardware description again.
+
+The event log carries machine-readable payloads: named, typed fields with a stable schema. The same captured log can be decoded offline, long after the simulation finished, as long as the schema (saved together with the log) and the event definitions are available.
+
+## Defining events
+
+Events are dataclasses declared with the `event` decorator. The event name must be globally unique:
+
+```python
+from transactron.evlog import Event, Static, event
+
+@event("exec.unit_start")
+class ExecUnitStart(Event):
+    insn_tag: int
+    kind: UnitKind          # an enum.Enum subclass
+    lane: Static[int]
+```
+
+There are two kinds of fields:
+
+- **dynamic** fields are backed by hardware signals, sampled in every cycle in which the event fires. Annotate them with the *decoded* Python type: `int`, `bool` or an `enum.Enum` subclass (raw integers are converted back to the annotated type when a log is decoded). Signal widths are not declared - they are inferred from the actual Amaranth values at elaboration time and recorded in the schema, so parameterized designs need no special handling.
+- **static** fields (annotated with `Static[...]`) hold plain Python values fixed at elaboration time and cost no hardware. Use them for properties of the emission site, such as a lane index or a unit name.
+
+## Emitting events
+
+`EventSource` mirrors the `HardwareLogger` API. Since during elaboration the dynamic fields hold Amaranth values rather than their declared types, instances are constructed with the `Event.hw` classmethod:
+
+```python
+from transactron.evlog import EventSource
+
+self.evlog = EventSource("exec.alu")
+...
+def elaborate(self, platform):
+    ...
+    self.evlog.emit(m, ExecUnitStart.hw(insn_tag=tag, kind=kind, lane=0), when=start)
+```
+
+The event fires in every cycle in which `when` is true and the surrounding module context (`m.If`, transaction or method body) is active. `top_emit` is available for contexts without a module. Emitting the same event type multiple times (e.g. once per superscalar lane, distinguished by a static field) creates separate emission sites.
+
+Event logging is disabled by default and `emit` is then a no-op, so instrumentation has no cost in synthesis flows. Enable it before elaboration with:
+
+```python
+DependencyContext.get().add_dependency(EvLogEnabledKey(), True)
+```
+
+## Capturing events
+
+Every emission site registered during elaboration is described by an `EvLogSchema`: the event name, source name, dynamic field names and widths, and static field values. The schema is the only contract between the elaborated design and event log consumers.
+
+With the Amaranth simulator, capture events with `transactron.testing.evlog`:
+
+```python
+from transactron.testing.evlog import capture_evlog
+
+with self.run_simulation(m) as sim:
+    log, process = capture_evlog(metadata={"config": "full"})
+    sim.add_process(process)
+    sim.add_testbench(testbench)
+
+events = log.decoded()      # or log.save("events.jsonl")
+```
+
+Tests based on `TestCaseWithSimulator` capture event logs automatically when pytest is invoked with `--transactron-evlog`: every test which registered any emission sites (i.e. tests which enabled the event log themselves) saves its captured events to `test/__evlogs__/<test name>.jsonl`. The flag only controls capturing - enabling the event log stays a separate concern.
+
+For generated Verilog, `generate_verilog` records the event log schema together with signal locations in `GenerationInfo.evlog`, including a packed vector of all event triggers so that a simulator only needs a single signal read per cycle to check all sites. `GeneratedEvLogSampler` samples events through any backend able to read signals by hierarchical location (e.g. cocotb on top of Verilator):
+
+```python
+from transactron.evlog import EventLogWriter, GeneratedEvLogSampler
+
+sampler = GeneratedEvLogSampler(gen_info.evlog, resolve_handle)
+with EventLogWriter("events.jsonl", gen_info.evlog.schema) as writer:
+    # once per clock cycle, when signals are stable (e.g. falling edge):
+    sampler.sample(cycle, writer)
+```
+
+## Event log files and consumers
+
+Event logs are stored as JSON lines: a header with the schema and free-form metadata, followed by one record per fired event. `EventLog.load` reads a log into memory; `EventLogReader` decodes it lazily for logs too large to hold in memory.
+
+The `transactron-evlog` command pretty-prints event log files. It works from the schema alone; passing `-m <module>` imports the event definitions so that enum fields are printed as member names:
+
+```
+$ transactron-evlog -m coreblocks.telemetry -f "ftq" -c 8:10 events.jsonl
+ 8 frontend.ftq frontend.ftq_alloc      ftq_ptr=4 pc=0x00000110
+ 8 frontend.ftq frontend.ftq_commit     ftq_ptr=0
+ 9 frontend.ftq frontend.ftq_rollback   ftq_ptr=2 cause=ifu_writeback
+10 frontend.ftq frontend.ftq_alloc      ftq_ptr=2 pc=0x00000200
+```
+
+`--schema` prints a summary of the emission sites instead; `-x`/`-d` force hex/decimal field values.
+
+Consumers subclass `EventConsumer` and declare one handler per event type; dispatch is keyed by the registered event name:
+
+```python
+from transactron.evlog import DecodedEvent, EventConsumer, EventLogReader, handles
+
+class KonataConverter(EventConsumer):
+    @handles(ExecUnitStart)
+    def on_unit_start(self, rec: DecodedEvent):
+        ...  # rec.cycle, rec.source_name, rec.event (typed ExecUnitStart)
+
+KonataConverter().run(EventLogReader("events.jsonl"))
+```
+
+`EventConsumer.run` sorts records by cycle, so capture order does not matter - which is convenient for output formats requiring monotonic timestamps. Events without a handler go to `on_unhandled`; override it to detect drift between the schema and the consumer.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,7 @@ maxdepth: 3
 getting-started.md
 transactions.md
 pipeline-guide.md
+evlog.md
 api.md
 development-environment.md
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ dev = [
 
 [project.scripts]
 transactron-prof = "transactron.cmd.tprof:main"
+transactron-evlog = "transactron.cmd.evlog:main"
 
 [tool.setuptools_scm]
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -6,6 +6,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     group = parser.getgroup("transactron")
     group.addoption("--transactron-traces", action="store_true", help="Generate traces from tests.")
     group.addoption("--transactron-profile", action="store_true", help="Write execution profiles.")
+    group.addoption("--transactron-evlog", action="store_true", help="Write captured event logs.")
     group.addoption("--transactron-log-filter", default=".*", action="store", help="Regexp used to filter out logs.")
 
 
@@ -19,6 +20,9 @@ def pytest_runtest_setup(item: pytest.Item) -> None:
 
     if item.config.getoption("--transactron-profile", False):  # type: ignore
         os.environ["__TRANSACTRON_PROFILE"] = "1"
+
+    if item.config.getoption("--transactron-evlog", False):  # type: ignore
+        os.environ["__TRANSACTRON_EVLOG"] = "1"
 
     log_filter = item.config.getoption("--transactron-log-filter")
     os.environ["__TRANSACTRON_LOG_FILTER"] = ".*" if not isinstance(log_filter, str) else log_filter

--- a/test/evlog/test_evlog.py
+++ b/test/evlog/test_evlog.py
@@ -1,0 +1,357 @@
+from enum import IntEnum
+from io import StringIO
+
+import pytest
+from amaranth import *
+from amaranth.lib.wiring import Component, In, Out
+
+from transactron import TModule
+from transactron.evlog import (
+    Event,
+    EventConsumer,
+    EventFieldSchema,
+    EventLog,
+    EventLogReader,
+    EventSiteLocation,
+    EventSiteSchema,
+    EventSource,
+    EvLogEnabledKey,
+    EvLogSchema,
+    GeneratedEvLog,
+    GeneratedEvLogSampler,
+    Static,
+    event,
+    get_emitted_events,
+    get_event_class,
+    handles,
+)
+from transactron.evlog.log import DecodedEvent
+from transactron.testing import TestCaseWithSimulator, TestbenchContext
+from transactron.testing.evlog import capture_evlog
+from transactron.utils.dependencies import DependencyContext
+
+
+class UnitKind(IntEnum):
+    ALU = 0
+    MUL = 1
+
+
+@event("test.insn_start")
+class InsnStart(Event):
+    tag: int
+    pc: int
+    kind: UnitKind
+    lane: Static[int]
+
+
+@event("test.insn_done")
+class InsnDone(Event):
+    tag: int
+    note: Static[str] = "done"
+
+
+class TestEventDefinition:
+    def test_field_split(self):
+        assert InsnStart.event_name == "test.insn_start"
+        assert InsnStart._dynamic_fields == ("tag", "pc", "kind")
+        assert InsnStart._static_fields == ("lane",)
+        assert get_event_class("test.insn_start") is InsnStart
+
+    def test_from_raw(self):
+        ev = InsnStart.from_raw({"tag": 3, "pc": 100, "kind": 1}, {"lane": 2})
+        assert ev == InsnStart(tag=3, pc=100, kind=UnitKind.MUL, lane=2)
+        assert isinstance(ev.kind, UnitKind)
+
+    def test_duplicate_name(self):
+        with pytest.raises(ValueError):
+
+            @event("test.insn_start")
+            class Duplicate(Event):
+                x: int
+
+    def test_unknown_event(self):
+        with pytest.raises(KeyError):
+            get_event_class("test.does_not_exist")
+
+
+class EvLogTestCircuit(Elaboratable):
+    def __init__(self):
+        self.tag = Signal(4)
+        self.pc = Signal(8)
+        self.kind = Signal(UnitKind)
+        self.start = Signal()
+        self.done = Signal()
+        self.evlog = EventSource("test.circuit")
+
+    def elaborate(self, platform):
+        m = TModule()
+
+        with m.If(self.start):
+            self.evlog.emit(m, InsnStart.hw(tag=self.tag, pc=self.pc, kind=self.kind, lane=0))
+
+        self.evlog.emit(m, InsnDone.hw(tag=self.tag), when=self.done)
+
+        return m
+
+
+class TestEvLogCapture(TestCaseWithSimulator):
+    def run_capture(self):
+        DependencyContext.get().add_dependency(EvLogEnabledKey(), True)
+        m = EvLogTestCircuit()
+
+        async def proc(sim: TestbenchContext):
+            sim.set(m.tag, 1)
+            sim.set(m.pc, 100)
+            sim.set(m.kind, UnitKind.MUL)
+            sim.set(m.start, 1)
+            await sim.tick()
+            sim.set(m.start, 0)
+            sim.set(m.done, 1)
+            await sim.tick()
+            sim.set(m.done, 0)
+            await sim.tick()
+
+        with self.run_simulation(m) as sim:
+            log, process = capture_evlog(metadata={"config": "test_config"})
+            sim.add_process(process)
+            sim.add_testbench(proc)
+
+        return log
+
+    def test_capture(self):
+        log = self.run_capture()
+
+        assert log.schema.metadata == {"config": "test_config"}
+        assert [site.event_name for site in log.schema.sites] == ["test.insn_start", "test.insn_done"]
+        assert log.schema.sites[0].source_name == "test.circuit"
+        assert log.schema.sites[0].statics == {"lane": 0}
+        assert log.schema.sites[0].fields == [
+            EventFieldSchema(name="tag", width=4),
+            EventFieldSchema(name="pc", width=8),
+            EventFieldSchema(name="kind", width=1),
+        ]
+        assert log.schema.sites[1].statics == {"note": "done"}
+
+        events = log.decoded()
+        assert len(events) == 2
+
+        start, done = events
+        assert start.source_name == "test.circuit"
+        assert start.event == InsnStart(tag=1, pc=100, kind=UnitKind.MUL, lane=0)
+        assert done.event == InsnDone(tag=1, note="done")
+        assert done.cycle == start.cycle + 1
+
+    def test_save_load_roundtrip(self, tmp_path):
+        log = self.run_capture()
+
+        path = str(tmp_path / "events.jsonl")
+        log.save(path)
+
+        loaded = EventLog.load(path)
+        assert loaded.schema == log.schema
+        assert loaded.raw == log.raw
+        assert loaded.decoded() == log.decoded()
+
+        reader = EventLogReader(path)
+        assert reader.schema == log.schema
+        assert list(reader) == log.decoded()
+
+    def test_disabled(self):
+        # Event log is disabled by default: no sites registered, empty log.
+        m = EvLogTestCircuit()
+
+        async def proc(sim: TestbenchContext):
+            sim.set(m.start, 1)
+            await sim.tick()
+            await sim.tick()
+
+        with self.run_simulation(m) as sim:
+            log, process = capture_evlog()
+            sim.add_process(process)
+            sim.add_testbench(proc)
+
+        assert get_emitted_events() == []
+        assert log.schema.sites == []
+        assert log.decoded() == []
+
+
+def make_synthetic_log() -> EventLog:
+    schema = EvLogSchema(
+        sites=[
+            EventSiteSchema(
+                source_name="test.src",
+                event_name="test.insn_start",
+                location=("file.py", 1),
+                fields=[
+                    EventFieldSchema(name="tag", width=4),
+                    EventFieldSchema(name="pc", width=8),
+                    EventFieldSchema(name="kind", width=1),
+                ],
+                statics={"lane": 1},
+            ),
+            EventSiteSchema(
+                source_name="test.src",
+                event_name="test.insn_done",
+                location=("file.py", 2),
+                fields=[EventFieldSchema(name="tag", width=4)],
+                statics={"note": "bye"},
+            ),
+        ]
+    )
+    log = EventLog(schema)
+    log.emit_raw(7, 0, [2, 50, 0])
+    log.emit_raw(3, 1, [2])
+    return log
+
+
+class TestEventConsumer:
+    def test_dispatch_sorted(self):
+        class Collector(EventConsumer):
+            def __init__(self):
+                self.seen: list[tuple[int, Event]] = []
+                self.unhandled: list[DecodedEvent] = []
+
+            @handles(InsnStart)
+            def on_start(self, rec: DecodedEvent):
+                self.seen.append((rec.cycle, rec.event))
+
+            def on_unhandled(self, rec: DecodedEvent):
+                self.unhandled.append(rec)
+
+        collector = Collector()
+        collector.run(make_synthetic_log().decoded())
+
+        assert collector.seen == [(7, InsnStart(tag=2, pc=50, kind=UnitKind.ALU, lane=1))]
+        assert [rec.cycle for rec in collector.unhandled] == [3]
+
+    def test_handler_inheritance(self):
+        class Base(EventConsumer):
+            @handles(InsnStart)
+            def on_start(self, rec: DecodedEvent):
+                pass
+
+        class Derived(Base):
+            @handles(InsnDone)
+            def on_done(self, rec: DecodedEvent):
+                pass
+
+        assert Base._handlers == {"test.insn_start": "on_start"}
+        assert Derived._handlers == {"test.insn_start": "on_start", "test.insn_done": "on_done"}
+
+
+class TestPrettyPrinter:
+    def print_lines(self, **kwargs) -> list[str]:
+        from transactron.cmd.evlog import print_events
+
+        kwargs = {"mode": "auto", "name_filter": None, "cycles": None} | kwargs
+        out = StringIO()
+        print_events(make_synthetic_log(), out, **kwargs)
+        return out.getvalue().splitlines()
+
+    def test_print_events(self):
+        # Sorted by cycle; enum fields printed as member names; fields wider
+        # than 8 bits in hex; statics appended.
+        assert self.print_lines() == [
+            "3 test.src test.insn_done   tag=2 note=bye",
+            "7 test.src test.insn_start  tag=2 pc=50 kind=ALU lane=1",
+        ]
+
+    def test_value_modes(self):
+        assert self.print_lines(mode="hex")[1].endswith("tag=0x2 pc=0x32 kind=ALU lane=1")
+        assert self.print_lines(mode="dec")[1].endswith("tag=2 pc=50 kind=ALU lane=1")
+
+    def test_filter_and_cycles(self):
+        assert len(self.print_lines(name_filter="insn_start")) == 1
+        assert len(self.print_lines(cycles="0:5")) == 1
+        assert len(self.print_lines(cycles="4:")) == 1
+
+    def test_main(self, tmp_path, capsys):
+        from transactron.cmd.evlog import main
+
+        path = str(tmp_path / "events.jsonl")
+        make_synthetic_log().save(path)
+
+        main([path, "-f", "insn_done", "-d"])
+        assert capsys.readouterr().out == "3 test.src test.insn_done  tag=2 note=bye\n"
+
+        main([path, "--schema"])
+        schema_out = capsys.readouterr().out
+        assert "test.insn_start (tag[4], pc[8], kind[1]) lane=1" in schema_out
+
+
+class TestGeneratedEvLogSampler:
+    def test_sampler(self):
+        log = make_synthetic_log()
+        generated = GeneratedEvLog(
+            schema=log.schema,
+            site_locations=[
+                EventSiteLocation(trigger=["top", "t0"], fields=[["top", "tag0"], ["top", "pc0"], ["top", "kind0"]]),
+                EventSiteLocation(trigger=["top", "t1"], fields=[["top", "tag1"]]),
+            ],
+            triggers_location=["top", "triggers"],
+        )
+
+        values = {"top.triggers": 0, "top.t0": 0, "top.t1": 0, "top.tag0": 2, "top.pc0": 50, "top.kind0": 0}
+        values["top.tag1"] = 3
+
+        def resolve(location):
+            key = ".".join(location)
+            return lambda: values[key]
+
+        sampler = GeneratedEvLogSampler(generated, resolve)
+        sink = EventLog(log.schema)
+
+        sampler.sample(0, sink)
+        assert sink.raw == []
+
+        values["top.triggers"] = 0b10
+        sampler.sample(1, sink)
+        assert sink.raw == [(1, 1, [3])]
+
+        values["top.triggers"] = 0b01
+        sampler.sample(2, sink)
+        assert sink.raw == [(1, 1, [3]), (2, 0, [2, 50, 0])]
+
+        # Without the packed trigger vector, per-site triggers are used.
+        generated_unpacked = GeneratedEvLog(
+            schema=generated.schema, site_locations=generated.site_locations, triggers_location=None
+        )
+        sampler = GeneratedEvLogSampler(generated_unpacked, resolve)
+        sink = EventLog(log.schema)
+        values["top.t1"] = 1
+        sampler.sample(5, sink)
+        assert sink.raw == [(5, 1, [3])]
+
+
+@event("test.gen_event")
+class GenEvent(Event):
+    value: int
+
+
+class GenTestCircuit(Component):
+    din: Signal
+    dout: Signal
+
+    def __init__(self):
+        super().__init__({"din": In(8), "dout": Out(8)})
+        self.evlog = EventSource("test.gen")
+
+    def elaborate(self, platform):
+        m = Module()
+        m.d.comb += self.dout.eq(self.din + 1)
+        self.evlog.emit(m, GenEvent.hw(value=self.din), when=self.din[0])
+        return m
+
+
+class TestEmitValidation(TestCaseWithSimulator):
+    def test_static_field_with_signal(self):
+        DependencyContext.get().add_dependency(EvLogEnabledKey(), True)
+        source = EventSource("test.validation")
+        with pytest.raises(TypeError):
+            source.top_emit(InsnStart.hw(tag=Signal(4), pc=Signal(8), kind=Signal(UnitKind), lane=Signal(2)))
+
+    def test_non_event(self):
+        DependencyContext.get().add_dependency(EvLogEnabledKey(), True)
+        source = EventSource("test.validation")
+        with pytest.raises(TypeError):
+            source.top_emit(42)  # type: ignore

--- a/transactron/cmd/evlog.py
+++ b/transactron/cmd/evlog.py
@@ -1,0 +1,149 @@
+import argparse
+import enum
+import importlib
+import json
+import re
+import signal
+import sys
+from typing import Any, Optional
+
+from transactron.evlog.event import get_event_class
+from transactron.evlog.log import EventLog
+from transactron.evlog.schema import EventSiteSchema
+
+
+def site_field_types(site: EventSiteSchema) -> dict[str, Any]:
+    """Returns the declared field types of the site's event, or an empty
+    mapping if the event type is not registered (its defining module was
+    not imported)."""
+    try:
+        return dict(get_event_class(site.event_name)._field_types)
+    except KeyError:
+        return {}
+
+
+def format_value(raw: int, width: int, field_type: Any, mode: str) -> str:
+    if isinstance(field_type, type) and issubclass(field_type, enum.Enum):
+        try:
+            return field_type(raw).name
+        except ValueError:
+            pass
+    if mode == "hex" or (mode == "auto" and width > 8):
+        return f"0x{raw:0{(width + 3) // 4}x}"
+    return str(raw)
+
+
+def format_static(value: Any, field_type: Any) -> str:
+    if isinstance(field_type, type) and issubclass(field_type, enum.Enum) and not isinstance(value, enum.Enum):
+        try:
+            return field_type(value).name
+        except ValueError:
+            pass
+    return str(value)
+
+
+def format_event(site: EventSiteSchema, values: list[int], mode: str) -> str:
+    field_types = site_field_types(site)
+    parts = [
+        f"{field.name}={format_value(value, field.width, field_types.get(field.name), mode)}"
+        for field, value in zip(site.fields, values)
+    ]
+    parts += [f"{name}={format_static(value, field_types.get(name))}" for name, value in site.statics.items()]
+    return " ".join(parts)
+
+
+def parse_cycle_range(spec: str) -> tuple[int, int]:
+    start, sep, end = spec.partition(":")
+    if not sep:
+        raise ValueError("Cycle range must have the START:END format")
+    return (int(start) if start else 0, int(end) if end else sys.maxsize)
+
+
+def print_schema(log: EventLog, out):
+    if log.schema.metadata:
+        print(f"metadata: {json.dumps(log.schema.metadata)}", file=out)
+    for idx, site in enumerate(log.schema.sites):
+        fields = ", ".join(f"{field.name}[{field.width}]" for field in site.fields)
+        statics = "".join(f" {name}={value}" for name, value in site.statics.items())
+        location = f"{site.location[0]}:{site.location[1]}"
+        print(f"{idx:>4} {site.source_name} {site.event_name} ({fields}){statics}  [{location}]", file=out)
+
+
+def print_events(log: EventLog, out, *, mode: str, name_filter: Optional[str], cycles: Optional[str]):
+    sites = log.schema.sites
+
+    selected = set(range(len(sites)))
+    if name_filter is not None:
+        pattern = re.compile(name_filter)
+        selected = {idx for idx in selected if pattern.search(f"{sites[idx].source_name} {sites[idx].event_name}")}
+
+    first_cycle, last_cycle = parse_cycle_range(cycles) if cycles is not None else (0, sys.maxsize)
+
+    records = [
+        (cycle, site, values)
+        for cycle, site, values in log.raw
+        if site in selected and first_cycle <= cycle <= last_cycle
+    ]
+    records.sort(key=lambda record: record[0])
+
+    if log.schema.metadata:
+        print(f"# metadata: {json.dumps(log.schema.metadata)}", file=out)
+    if not records:
+        return
+
+    cycle_width = len(str(records[-1][0]))
+    source_width = max(len(sites[site].source_name) for _, site, _ in records)
+    event_width = max(len(sites[site].event_name) for _, site, _ in records)
+
+    for cycle, site_idx, values in records:
+        site = sites[site_idx]
+        print(
+            f"{cycle:>{cycle_width}} {site.source_name:<{source_width}} "
+            f"{site.event_name:<{event_width}}  {format_event(site, values, mode)}",
+            file=out,
+        )
+
+
+def main(argv: Optional[list[str]] = None):
+    # Die silently when the output is piped to e.g. `head`.
+    if hasattr(signal, "SIGPIPE"):
+        signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+
+    parser = argparse.ArgumentParser(description="Pretty-print evlog event log files.")
+    parser.add_argument("path", help="The event log file (JSON lines)")
+    parser.add_argument(
+        "-m",
+        "--module",
+        action="append",
+        default=[],
+        help="Module with event definitions to import (e.g. coreblocks.telemetry); can be repeated. "
+        "Without it, events are still printed, but enum fields are not converted to member names.",
+    )
+    parser.add_argument("-f", "--filter", help="Regex selecting events by their 'source event' name")
+    parser.add_argument("-c", "--cycles", help="Only show events in the START:END cycle range (bounds optional)")
+    value_format = parser.add_mutually_exclusive_group()
+    value_format.add_argument(
+        "-x",
+        "--hex",
+        action="store_true",
+        help="Print all field values in hex (default: only fields wider than 8 bits)",
+    )
+    value_format.add_argument("-d", "--dec", action="store_true", help="Print all field values in decimal")
+    parser.add_argument("--schema", action="store_true", help="Print the schema summary instead of the events")
+    args = parser.parse_args(argv)
+
+    for module in args.module:
+        importlib.import_module(module)
+
+    log = EventLog.load(args.path)
+
+    if args.schema:
+        print_schema(log, sys.stdout)
+        return
+
+    mode = "hex" if args.hex else "dec" if args.dec else "auto"
+    print_events(log, sys.stdout, mode=mode, name_filter=args.filter, cycles=args.cycles)
+
+
+if __name__ == "__main__":
+    main()

--- a/transactron/evlog/__init__.py
+++ b/transactron/evlog/__init__.py
@@ -1,0 +1,6 @@
+from .event import *  # noqa: F401
+from .emit import *  # noqa: F401
+from .schema import *  # noqa: F401
+from .log import *  # noqa: F401
+from .consumer import *  # noqa: F401
+from .sampler import *  # noqa: F401

--- a/transactron/evlog/consumer.py
+++ b/transactron/evlog/consumer.py
@@ -1,0 +1,70 @@
+from collections.abc import Iterable
+from typing import Any, Callable, ClassVar
+
+from .event import Event
+from .log import DecodedEvent
+
+
+__all__ = ["handles", "EventConsumer"]
+
+
+def handles(event_type: type[Event]):
+    """Marks an `EventConsumer` method as the handler for an event type.
+
+    The decorated method is called with a single `DecodedEvent` argument for
+    every log record of the given event type.
+    """
+
+    def wrap(fn):
+        fn._evlog_handles = event_type
+        return fn
+
+    return wrap
+
+
+class EventConsumer:
+    """Base class for event log consumers.
+
+    Subclasses implement one `handles`-decorated method per consumed event
+    type, e.g. a converter to a trace format::
+
+        class KonataConverter(EventConsumer):
+            @handles(InsnStageEnter)
+            def on_stage_enter(self, rec: DecodedEvent): ...
+
+    Handlers are dispatched by the registered event name, so the consumer
+    works with logs decoded from any capture backend. Events without a
+    handler are passed to `on_unhandled`, which does nothing by default.
+    """
+
+    _handlers: ClassVar[dict[str, str]] = {}
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        handlers = dict(cls._handlers)
+        for name, fn in vars(cls).items():
+            handled = getattr(fn, "_evlog_handles", None)
+            if handled is not None:
+                handlers[handled.event_name] = name
+        cls._handlers = handlers
+
+    def dispatch(self, rec: DecodedEvent):
+        """Calls the handler registered for the record's event type."""
+        name = self._handlers.get(rec.event.event_name)
+        if name is None:
+            self.on_unhandled(rec)
+        else:
+            handler: Callable[[DecodedEvent], Any] = getattr(self, name)
+            handler(rec)
+
+    def on_unhandled(self, rec: DecodedEvent):
+        """Called for events without a registered handler."""
+
+    def run(self, records: Iterable[DecodedEvent]):
+        """Dispatches all records, sorted by cycle.
+
+        Sorting makes the consumer independent of the capture order, which
+        matters for consumers of formats requiring monotonic timestamps.
+        """
+        for rec in sorted(records, key=lambda rec: rec.cycle):
+            self.dispatch(rec)

--- a/transactron/evlog/emit.py
+++ b/transactron/evlog/emit.py
@@ -1,0 +1,169 @@
+from dataclasses import dataclass
+from typing import Any
+
+from amaranth import *
+from amaranth.hdl import ValueCastable
+from amaranth_types import ModuleLike, ValueLike
+
+from transactron.utils.transactron_helpers import SrcLoc, get_src_loc, local_src_loc
+from transactron.utils.dependencies import DependencyContext, ListKey, SimpleKey
+
+from .event import Event, static_to_raw
+
+
+__all__ = ["EmittedEvent", "EvLogKey", "EvLogEnabledKey", "EventSource", "evlog_enabled", "get_emitted_events"]
+
+
+@dataclass
+class EmittedEvent:
+    """A single event emission site registered during elaboration.
+
+    Attributes
+    ----------
+    source_name: str
+        Name of the `EventSource` which registered this site.
+    event_type: type[Event]
+        The event type emitted at this site.
+    location: SrcLoc
+        Source location of the emission site.
+    trigger: Value
+        Single-bit Amaranth value. The event is recorded in every cycle in
+        which the trigger is high.
+    fields: dict[str, Value]
+        Amaranth values backing the dynamic fields.
+    statics: dict[str, Any]
+        JSON-serializable values of the static fields.
+    """
+
+    source_name: str
+    event_type: type[Event]
+    location: SrcLoc
+    trigger: Value
+    fields: dict[str, Value]
+    statics: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class EvLogKey(ListKey[EmittedEvent]):
+    """DependencyManager key collecting all event emission sites."""
+
+
+@dataclass(frozen=True)
+class EvLogEnabledKey(SimpleKey[bool]):
+    """DependencyManager key for enabling the event log. If the event log
+    is disabled (the default), `EventSource.emit` is a no-op and no signals
+    are synthesized."""
+
+    empty_valid = True
+    default_value = False
+
+
+def evlog_enabled() -> bool:
+    """Checks if event logging is enabled in the current dependency context."""
+    return DependencyContext.get().get_dependency(EvLogEnabledKey())
+
+
+def get_emitted_events() -> list[EmittedEvent]:
+    """Returns all event emission sites registered during elaboration,
+    in registration order."""
+    return DependencyContext.get().get_dependency(EvLogKey())
+
+
+class EventSource:
+    """Emission point for structured hardware events.
+
+    An `EventSource` emits typed events (see `Event`) from the hardware
+    description. Events are captured during simulation into an event log,
+    which can be consumed by downstream tools (trace converters, statistics
+    scripts) without touching the hardware description again.
+
+    Like `HardwareLogger`, event sources are identified by a hierarchical
+    dotted name, e.g. "frontend.ftq". Emitting the same event type multiple
+    times (e.g. once per superscalar lane) is allowed; each `emit` call
+    creates a separate emission site, typically distinguished by a static
+    field. Usage::
+
+        self.evlog = EventSource("exec.alu")
+        ...
+        self.evlog.emit(m, ExecUnitStart.hw(insn_tag=tag, lane=0), when=start)
+
+    Attributes
+    ----------
+    name: str
+        Name of this event source.
+    """
+
+    def __init__(self, name: str):
+        """
+        Parameters
+        ----------
+        name: str
+            Name of this event source. Hierarchy levels are separated by
+            periods, e.g. "frontend.ftq".
+        """
+        self.name = name
+
+    def emit(self, m: ModuleLike, ev: Event, *, when: ValueLike = 1, src_loc: int | SrcLoc = 0):
+        """Registers an event emission site.
+
+        The event is recorded in every cycle in which `when` is true and the
+        surrounding module context (`m.If` etc., transaction or method body)
+        is active.
+
+        Parameters
+        ----------
+        m: ModuleLike
+            The module in which the event is emitted.
+        ev: Event
+            The emitted event. Dynamic fields must be Amaranth values;
+            static fields must be plain Python values.
+        when: ValueLike
+            The event is recorded in cycles in which this Amaranth expression
+            is true. Defaults to always (gated only by the module context).
+        src_loc: int | SrcLoc, optional
+            How many stack frames below to look for the source location.
+        """
+        if not evlog_enabled():
+            return
+        trigger = Signal()
+        m.d.comb += trigger.eq(Value.cast(when).any())
+        self.top_emit(ev, when=trigger, src_loc=get_src_loc(src_loc))
+
+    def top_emit(self, ev: Event, *, when: ValueLike = 1, src_loc: int | SrcLoc = 0):
+        """Registers an event emission site.
+
+        Unlike `EventSource.emit`, this function ignores `m.If` etc. and can
+        be used in contexts where a module is not available.
+
+        See `EventSource.emit` for details.
+        """
+        if not evlog_enabled():
+            return
+
+        cls = type(ev)
+        if not (isinstance(ev, Event) and hasattr(cls, "event_name")):
+            raise TypeError(f"Emitted object must be an instance of an @event-decorated Event subclass, got: {ev!r}")
+
+        fields: dict[str, Value] = {}
+        for name in cls._dynamic_fields:
+            value = getattr(ev, name)
+            if not isinstance(value, (Value, ValueCastable, int, bool)):
+                raise TypeError(f"Dynamic field '{name}' of event '{cls.event_name}' must be an Amaranth value")
+            fields[name] = Value.cast(value)
+
+        statics: dict[str, Any] = {}
+        for name in cls._static_fields:
+            value = getattr(ev, name)
+            if isinstance(value, (Value, ValueCastable)):
+                raise TypeError(f"Static field '{name}' of event '{cls.event_name}' must be a plain Python value")
+            statics[name] = static_to_raw(value)
+
+        record = EmittedEvent(
+            source_name=self.name,
+            event_type=cls,
+            location=local_src_loc(get_src_loc(src_loc)),
+            trigger=Value.cast(when).any(),
+            fields=fields,
+            statics=statics,
+        )
+        DependencyContext.get().add_dependency(EvLogKey(), record)

--- a/transactron/evlog/event.py
+++ b/transactron/evlog/event.py
@@ -1,0 +1,172 @@
+import enum
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, fields
+from typing import Annotated, Any, ClassVar, Self, TypeVar, dataclass_transform, get_args, get_origin, get_type_hints
+
+
+__all__ = ["Static", "Event", "event", "get_event_class"]
+
+
+class _StaticMarker:
+    """Marker used in `Annotated` metadata to denote static event fields."""
+
+
+type Static[T] = Annotated[T, _StaticMarker]
+"""Annotation for static event fields.
+
+Static fields hold plain Python values which are fixed at emission
+(elaboration) time. They are stored in the event log schema and don't
+cost any hardware. Use them for properties of the emission site, e.g.
+a lane index or a unit name::
+
+    @event("exec.unit_start")
+    class ExecUnitStart(Event):
+        insn_tag: int
+        lane: Static[int]
+"""
+
+
+def _split_hint(hint: Any) -> tuple[bool, Any]:
+    """Splits a field type annotation into (is static, underlying type)."""
+    if get_origin(hint) is Static:
+        return True, get_args(hint)[0]
+    if get_origin(hint) is Annotated and _StaticMarker in get_args(hint)[1:]:
+        return True, get_args(hint)[0]
+    return False, hint
+
+
+def _convert_field(field_type: Any, raw):
+    if isinstance(field_type, type):
+        if issubclass(field_type, enum.Enum):
+            return field_type(raw)
+        if field_type is bool:
+            return bool(raw)
+    return raw
+
+
+def static_to_raw(value: Any) -> Any:
+    """Converts a static field value to its JSON-serializable representation."""
+    if isinstance(value, enum.Enum):
+        return value.value
+    return value
+
+
+class Event:
+    """Base class for event types.
+
+    Concrete event types subclass `Event` and are declared using the `event`
+    decorator, which turns them into dataclasses. Fields annotated with
+    `Static[...]` are static; all other fields are dynamic and are backed by
+    hardware signals sampled during simulation.
+
+    The same class is used in two contexts:
+
+    - during elaboration, instances are constructed with Amaranth values for
+      the dynamic fields and passed to `EventSource.emit`;
+    - when reading a captured event log, decoded instances carry concrete
+      Python values.
+
+    Dynamic fields should be annotated with `int`, `bool` or an `enum.Enum`
+    subclass; raw integers are converted according to the annotation when
+    an event log is decoded.
+    """
+
+    event_name: ClassVar[str]
+    """Unique dotted name of the event type, e.g. "fetch.block_started"."""
+
+    _dynamic_fields: ClassVar[tuple[str, ...]]
+    _static_fields: ClassVar[tuple[str, ...]]
+    _field_types: ClassVar[Mapping[str, Any]]
+
+    @classmethod
+    def hw(cls, **fields: Any) -> Self:
+        """Constructs an event instance for emission from hardware.
+
+        Behaves exactly like the regular constructor, but accepts arbitrary
+        values, as during elaboration the dynamic fields hold Amaranth values
+        instead of the declared (decoded) field types. Field values are
+        validated by `EventSource.emit`.
+        """
+        return cls(**fields)
+
+    @classmethod
+    def from_raw(cls, dynamics: Mapping[str, int], statics: Mapping[str, Any]) -> Self:
+        """Reconstructs a typed event instance from raw field values.
+
+        Parameters
+        ----------
+        dynamics: Mapping[str, int]
+            Raw values of the dynamic fields, as sampled from hardware signals.
+        statics: Mapping[str, Any]
+            Raw values of the static fields, as stored in the event schema.
+        """
+        kwargs: dict[str, Any] = {}
+        for name in cls._dynamic_fields:
+            kwargs[name] = _convert_field(cls._field_types[name], dynamics[name])
+        for name in cls._static_fields:
+            kwargs[name] = _convert_field(cls._field_types[name], statics[name])
+        return cls(**kwargs)
+
+
+_event_registry: dict[str, type[Event]] = {}
+
+
+def get_event_class(name: str) -> type[Event]:
+    """Looks up an event type by its registered name.
+
+    The module defining the event type must have been imported beforehand,
+    as event types register themselves at class definition time.
+    """
+    if name not in _event_registry:
+        raise KeyError(
+            f"Unknown event type '{name}'. The module which defines this event must be imported before decoding."
+        )
+    return _event_registry[name]
+
+
+_T = TypeVar("_T", bound=type[Event])
+
+
+@dataclass_transform(eq_default=True)
+def event(name: str) -> Callable[[_T], _T]:
+    """Class decorator declaring a new event type.
+
+    The decorated class must subclass `Event`. It is converted to a dataclass
+    and registered globally under the given name, which must be unique.
+
+    Parameters
+    ----------
+    name: str
+        Unique dotted name of the event type, e.g. "fetch.block_started".
+        Recorded in event log schemas and used to look up the event type
+        when a log is decoded.
+    """
+
+    def decorator(cls: _T) -> _T:
+        if not (isinstance(cls, type) and issubclass(cls, Event)):  # pyright: ignore[reportUnnecessaryIsInstance]
+            raise TypeError(f"Class '{cls.__name__}' decorated with @event must subclass Event")
+        if name in _event_registry:
+            raise ValueError(f"Event name '{name}' is already registered by {_event_registry[name].__qualname__}")
+
+        dcls = dataclass(cls)
+        hints = get_type_hints(dcls, include_extras=True)
+
+        dynamic: list[str] = []
+        static: list[str] = []
+        field_types: dict[str, Any] = {}
+        for f in fields(dcls):  # type: ignore[arg-type]
+            is_static, field_type = _split_hint(hints[f.name])
+            field_types[f.name] = field_type
+            if is_static:
+                static.append(f.name)
+            else:
+                dynamic.append(f.name)
+
+        dcls.event_name = name
+        dcls._dynamic_fields = tuple(dynamic)
+        dcls._static_fields = tuple(static)
+        dcls._field_types = field_types
+        _event_registry[name] = dcls
+        return dcls
+
+    return decorator

--- a/transactron/evlog/log.py
+++ b/transactron/evlog/log.py
@@ -1,0 +1,187 @@
+import json
+from collections.abc import Iterator, Sequence
+from dataclasses import dataclass
+from typing import Optional, Protocol, TextIO, runtime_checkable
+
+from .event import Event, get_event_class
+from .schema import EvLogSchema, EventSiteSchema
+
+
+__all__ = [
+    "RawEvent",
+    "DecodedEvent",
+    "RawEventSink",
+    "EventDecoder",
+    "EventLog",
+    "EventLogWriter",
+    "EventLogReader",
+]
+
+
+RawEvent = tuple[int, int, list[int]]
+"""A raw event record: (cycle, site index, dynamic field values in schema order)."""
+
+
+@dataclass
+class DecodedEvent:
+    """A single decoded event from an event log.
+
+    Attributes
+    ----------
+    cycle: int
+        The clock cycle in which the event was recorded.
+    site: EventSiteSchema
+        Schema of the emission site which produced the event.
+    event: Event
+        The typed event instance, with dynamic and static fields filled in.
+    """
+
+    cycle: int
+    site: EventSiteSchema
+    event: Event
+
+    @property
+    def source_name(self) -> str:
+        return self.site.source_name
+
+
+@runtime_checkable
+class RawEventSink(Protocol):
+    """Protocol for consumers of raw event records produced by samplers."""
+
+    def emit_raw(self, cycle: int, site: int, values: Sequence[int]) -> None: ...
+
+
+class EventDecoder:
+    """Decodes raw event records into typed `Event` instances using a schema.
+
+    The modules defining the used event types must be imported beforehand,
+    as event types are looked up in the global registry by name.
+    """
+
+    def __init__(self, schema: EvLogSchema):
+        self.schema = schema
+        self._site_classes = [get_event_class(site.event_name) for site in schema.sites]
+
+    def decode(self, cycle: int, site_idx: int, values: Sequence[int]) -> DecodedEvent:
+        site = self.schema.sites[site_idx]
+        if len(values) != len(site.fields):
+            raise ValueError(
+                f"Site {site_idx} ('{site.event_name}') expects {len(site.fields)} field values, got {len(values)}"
+            )
+        dynamics = {field.name: value for field, value in zip(site.fields, values)}
+        event = self._site_classes[site_idx].from_raw(dynamics, site.statics)
+        return DecodedEvent(cycle=cycle, site=site, event=event)
+
+
+def _write_header(fp: TextIO, schema: EvLogSchema):
+    fp.write(json.dumps(schema.to_dict()) + "\n")  # type: ignore
+
+
+def _read_header(fp: TextIO) -> EvLogSchema:
+    return EvLogSchema.from_dict(json.loads(fp.readline()))  # type: ignore
+
+
+class EventLog:
+    """An in-memory event log: raw event records paired with their schema.
+
+    Events are stored raw (as integers) and decoded on demand. The log is
+    serialized in the JSON-lines format: a header line containing the schema,
+    followed by one line per event.
+
+    Attributes
+    ----------
+    schema: EvLogSchema
+        Schema used to decode the raw records.
+    raw: list[RawEvent]
+        The raw event records, in capture order.
+    """
+
+    def __init__(self, schema: EvLogSchema):
+        self.schema = schema
+        self.raw: list[RawEvent] = []
+
+    def emit_raw(self, cycle: int, site: int, values: Sequence[int]) -> None:
+        self.raw.append((cycle, site, list(values)))
+
+    def decoded(self) -> list[DecodedEvent]:
+        """Decodes all events, in capture order."""
+        decoder = EventDecoder(self.schema)
+        return [decoder.decode(cycle, site, values) for cycle, site, values in self.raw]
+
+    def save(self, filename: str):
+        """Saves the event log to a JSON-lines file."""
+        with open(filename, "w") as fp:
+            _write_header(fp, self.schema)
+            for cycle, site, values in self.raw:
+                fp.write(json.dumps([cycle, site, values]) + "\n")
+
+    @staticmethod
+    def load(filename: str) -> "EventLog":
+        """Loads an event log from a JSON-lines file."""
+        with open(filename, "r") as fp:
+            log = EventLog(_read_header(fp))
+            for line in fp:
+                line = line.strip()
+                if not line:
+                    continue
+                cycle, site, values = json.loads(line)
+                log.raw.append((cycle, site, values))
+        return log
+
+
+class EventLogWriter:
+    """Streams raw event records directly to a JSON-lines file.
+
+    Unlike `EventLog.save`, records are not kept in memory, so arbitrarily
+    long simulations can be captured. Can be used as a context manager.
+    """
+
+    def __init__(self, filename: str, schema: EvLogSchema):
+        self.schema = schema
+        self._fp: Optional[TextIO] = open(filename, "w")
+        _write_header(self._fp, schema)
+
+    def emit_raw(self, cycle: int, site: int, values: Sequence[int]) -> None:
+        assert self._fp is not None, "Event log writer is closed"
+        self._fp.write(json.dumps([cycle, site, list(values)]) + "\n")
+
+    def close(self):
+        if self._fp is not None:
+            self._fp.close()
+            self._fp = None
+
+    def __enter__(self) -> "EventLogWriter":
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        self.close()
+
+
+class EventLogReader:
+    """Streaming reader of JSON-lines event log files.
+
+    Decodes events lazily while iterating, so arbitrarily long event logs can
+    be processed with constant memory usage.
+
+    Attributes
+    ----------
+    schema: EvLogSchema
+        The schema read from the event log header.
+    """
+
+    def __init__(self, filename: str):
+        self._filename = filename
+        with open(filename, "r") as fp:
+            self.schema = _read_header(fp)
+
+    def __iter__(self) -> Iterator[DecodedEvent]:
+        decoder = EventDecoder(self.schema)
+        with open(self._filename, "r") as fp:
+            fp.readline()  # skip the header
+            for line in fp:
+                line = line.strip()
+                if not line:
+                    continue
+                cycle, site, values = json.loads(line)
+                yield decoder.decode(cycle, site, values)

--- a/transactron/evlog/sampler.py
+++ b/transactron/evlog/sampler.py
@@ -1,0 +1,62 @@
+from collections.abc import Callable
+
+from .log import RawEventSink
+from .schema import GeneratedEvLog, SignalHandle
+
+
+__all__ = ["SignalReader", "HandleResolver", "GeneratedEvLogSampler"]
+
+
+SignalReader = Callable[[], int]
+"""Reads the current value of a single signal in a running (or replayed)
+simulation."""
+
+HandleResolver = Callable[[SignalHandle], SignalReader]
+"""Resolves the location of a signal in generated Verilog code to a reader
+of its value. Resolution happens once per signal, so the resolver can cache
+simulator handles."""
+
+
+class GeneratedEvLogSampler:
+    """Simulator-agnostic event sampler for generated (Verilog) designs.
+
+    The sampler reads event signals through readers obtained from a
+    `HandleResolver`, so the same code works with any backend able to read
+    signals by their hierarchical location.
+
+    `sample` should be called once per clock cycle, at a moment when the
+    sampled signals are stable (e.g. on the falling clock edge). If the
+    generated design provides a packed trigger vector, only a single signal
+    read per cycle is needed to check all emission sites.
+    """
+
+    def __init__(self, generated: GeneratedEvLog, resolve: HandleResolver):
+        """
+        Parameters
+        ----------
+        generated: GeneratedEvLog
+            Event log information from `GenerationInfo`.
+        resolve: HandleResolver
+            Backend-specific signal location resolver.
+        """
+        self.generated = generated
+        self._packed_triggers = (
+            resolve(generated.triggers_location) if generated.triggers_location is not None else None
+        )
+        self._sites = [
+            (resolve(loc.trigger), [resolve(field) for field in loc.fields]) for loc in generated.site_locations
+        ]
+
+    def sample(self, cycle: int, sink: RawEventSink) -> None:
+        """Samples all emission sites and reports fired events to the sink."""
+        if self._packed_triggers is not None:
+            packed = self._packed_triggers()
+            if not packed:
+                return
+            for site, (_, field_readers) in enumerate(self._sites):
+                if packed >> site & 1:
+                    sink.emit_raw(cycle, site, [read() for read in field_readers])
+        else:
+            for site, (trigger_reader, field_readers) in enumerate(self._sites):
+                if trigger_reader():
+                    sink.emit_raw(cycle, site, [read() for read in field_readers])

--- a/transactron/evlog/schema.py
+++ b/transactron/evlog/schema.py
@@ -1,0 +1,154 @@
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from typing import Any, Optional, TypeAlias
+
+from dataclasses_json import dataclass_json
+
+from transactron.utils.transactron_helpers import SrcLoc
+
+from .emit import EmittedEvent
+
+
+__all__ = [
+    "SignalHandle",
+    "EventFieldSchema",
+    "EventSiteSchema",
+    "EvLogSchema",
+    "EventSiteLocation",
+    "GeneratedEvLog",
+    "schema_from_records",
+]
+
+
+SignalHandle: TypeAlias = list[str]
+"""The location of a signal in generated Verilog code: a list of Verilog
+identifiers denoting a path of module names with the signal name at the end."""
+
+
+@dataclass_json
+@dataclass
+class EventFieldSchema:
+    """Schema of a single dynamic event field.
+
+    Attributes
+    ----------
+    name: str
+        Name of the field.
+    width: int
+        Bit width of the backing hardware signal.
+    signed: bool
+        Whether the backing hardware signal is signed.
+    """
+
+    name: str
+    width: int
+    signed: bool = False
+
+
+@dataclass_json
+@dataclass
+class EventSiteSchema:
+    """Schema of a single event emission site.
+
+    Attributes
+    ----------
+    source_name: str
+        Name of the `EventSource` which registered this site.
+    event_name: str
+        Registered name of the emitted event type.
+    location: SrcLoc
+        Source location of the emission site.
+    fields: list[EventFieldSchema]
+        Dynamic fields, in declaration order. Raw event records store field
+        values in this order.
+    statics: dict[str, Any]
+        Values of the static fields.
+    """
+
+    source_name: str
+    event_name: str
+    location: SrcLoc
+    fields: list[EventFieldSchema]
+    statics: dict[str, Any]
+
+
+@dataclass_json
+@dataclass
+class EvLogSchema:
+    """The decoding contract between an elaborated design and event log consumers.
+
+    A schema lists all event emission sites of a single elaboration. Raw event
+    records reference sites by their index in `sites`. The schema is stored
+    together with captured event logs, so that they can be decoded offline.
+
+    Attributes
+    ----------
+    sites: list[EventSiteSchema]
+        All event emission sites, in registration order.
+    metadata: dict[str, Any]
+        Free-form, JSON-serializable metadata describing the elaborated design
+        (e.g. the core configuration), for use by downstream consumers.
+    """
+
+    sites: list[EventSiteSchema]
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass_json
+@dataclass
+class EventSiteLocation:
+    """Locations of one emission site's signals in generated Verilog code.
+
+    Attributes
+    ----------
+    trigger: SignalHandle
+        Location of the trigger signal.
+    fields: list[SignalHandle]
+        Locations of the dynamic field signals, in schema field order.
+    """
+
+    trigger: SignalHandle
+    fields: list[SignalHandle]
+
+
+@dataclass_json
+@dataclass
+class GeneratedEvLog:
+    """Event log information for a generated (Verilog) design.
+
+    Attributes
+    ----------
+    schema: EvLogSchema
+        The event log schema.
+    site_locations: list[EventSiteLocation]
+        Signal locations for each site, indexed like `schema.sites`.
+    triggers_location: Optional[SignalHandle]
+        Location of a packed vector of all site triggers (bit `i` is the
+        trigger of site `i`). Allows a sampler to check all sites with a
+        single signal read per cycle. `None` if there are no sites.
+    """
+
+    schema: EvLogSchema
+    site_locations: list[EventSiteLocation]
+    triggers_location: Optional[SignalHandle] = None
+
+
+def schema_from_records(records: Iterable[EmittedEvent], metadata: Optional[dict[str, Any]] = None) -> EvLogSchema:
+    """Builds an event log schema from the emission sites registered during
+    elaboration (see `get_emitted_events`)."""
+    sites: list[EventSiteSchema] = []
+    for rec in records:
+        fields_schema: list[EventFieldSchema] = []
+        for name, value in rec.fields.items():
+            shape = value.shape()
+            fields_schema.append(EventFieldSchema(name=name, width=shape.width, signed=bool(shape.signed)))
+        sites.append(
+            EventSiteSchema(
+                source_name=rec.source_name,
+                event_name=rec.event_type.event_name,
+                location=rec.location,
+                fields=fields_schema,
+                statics=dict(rec.statics),
+            )
+        )
+    return EvLogSchema(sites=sites, metadata=dict(metadata or {}))

--- a/transactron/testing/__init__.py
+++ b/transactron/testing/__init__.py
@@ -10,6 +10,7 @@ from .method_mock import *  # noqa: F401
 from .testbenchio import *  # noqa: F401
 from .profiler import *  # noqa: F401
 from .logging import *  # noqa: F401
+from .evlog import *  # noqa: F401
 from .tick_count import *  # noqa: F401
 from .test_case import *  # noqa: F401
 

--- a/transactron/testing/evlog.py
+++ b/transactron/testing/evlog.py
@@ -1,0 +1,59 @@
+from itertools import chain
+from typing import Any, Optional
+
+from amaranth.sim._async import ProcessContext
+
+from transactron.utils.dependencies import DependencyContext
+from transactron.evlog import EmittedEvent, EventLog, RawEventSink, get_emitted_events, schema_from_records
+from .tick_count import TicksKey
+
+
+__all__ = ["capture_evlog"]
+
+
+def _make_evlog_process(sink: RawEventSink, records: Optional[list[EmittedEvent]]):
+    """Creates a simulation process which samples all registered event
+    emission sites every clock cycle and reports fired events to the sink.
+    """
+
+    async def evlog_process(sim: ProcessContext):
+        if not records:
+            return
+
+        ticks = DependencyContext.get().get_dependency(TicksKey())
+
+        to_sample = chain.from_iterable((rec.trigger, *rec.fields.values()) for rec in records)
+        tick_trigger = sim.tick().sample(ticks).sample(*to_sample)
+
+        async for _, _, ticks_val, *values in tick_trigger:
+            it = iter(values)
+            for site, rec in enumerate(records):
+                trigger = next(it)
+                field_values = [next(it) for _ in rec.fields]
+                if trigger:
+                    sink.emit_raw(ticks_val, site, field_values)
+
+    return evlog_process
+
+
+def capture_evlog(metadata: Optional[dict[str, Any]] = None):
+    """Creates an in-memory event log capturing all registered event emission
+    sites, together with the simulation process filling it.
+
+    Must be called after the design is elaborated. Usage::
+
+        with self.run_simulation(m) as sim:
+            log, process = capture_evlog()
+            sim.add_process(process)
+            sim.add_testbench(...)
+
+        events = log.decoded()
+
+    Parameters
+    ----------
+    metadata: dict[str, Any], optional
+        Metadata stored in the event log schema.
+    """
+    records = get_emitted_events()
+    log = EventLog(schema_from_records(records, metadata))
+    return log, _make_evlog_process(log, records)

--- a/transactron/testing/test_case.py
+++ b/transactron/testing/test_case.py
@@ -9,7 +9,9 @@ from amaranth import *
 from amaranth.sim import *
 from amaranth_types import HasElaborate
 
+from transactron.evlog import EventLog
 from transactron.utils.dependencies import DependencyContext, DependencyManager
+from .evlog import capture_evlog
 from .profiler import profiler_process, Profile
 from .logging import make_logging_process, parse_logging_level, _LogFormatter
 from .tick_count import make_tick_count_process
@@ -80,6 +82,25 @@ class TestCaseWithSimulatorBase:
             profile.encode(f"{profile_dir}/{profile_file}.json")
 
     @contextmanager
+    def _configure_evlog(self):
+        log: Optional[EventLog] = None
+        if "__TRANSACTRON_EVLOG" in os.environ:
+
+            def f():
+                nonlocal log
+                log, process = capture_evlog()
+                return process
+
+            self._transactron_sim_processes_to_add.append(f)
+
+        yield
+
+        if log is not None and log.schema.sites:
+            evlog_dir = "test/__evlogs__"
+            os.makedirs(evlog_dir, exist_ok=True)
+            log.save(f"{evlog_dir}/{self._transactron_current_output_file_name}.jsonl")
+
+    @contextmanager
     def _configure_logging(self):
         def on_error():
             assert False, "Simulation finished due to an error"
@@ -111,9 +132,10 @@ class TestCaseWithSimulatorBase:
         with self._configure_dependency_context():
             self._configure_traces()
             with self._configure_profiles():
-                with self._configure_logging():
-                    self._transactron_sim_processes_to_add.append(make_tick_count_process)
-                    yield
+                with self._configure_evlog():
+                    with self._configure_logging():
+                        self._transactron_sim_processes_to_add.append(make_tick_count_process)
+                        yield
         self._transactron_hypothesis_iter_counter += 1
 
     @contextmanager

--- a/transactron/utils/gen.py
+++ b/transactron/utils/gen.py
@@ -10,6 +10,8 @@ from amaranth_types import AbstractInterface
 from transactron.core import TransactionManager
 from transactron.core.keys import TransactionManagerKey
 from transactron.core.manager import MethodMap
+from transactron.evlog import EmittedEvent, EventSiteLocation, GeneratedEvLog, get_emitted_events
+from transactron.evlog.schema import schema_from_records
 from transactron.lib.metrics import HardwareMetricsManager
 from transactron.utils import logging
 from transactron.utils.dependencies import DependencyContext
@@ -113,6 +115,8 @@ class GenerationInfo:
         of its registers.
     logs : list[GeneratedLog]
         Locations and metadata for all log records.
+    evlog : GeneratedEvLog
+        Event log schema and signal locations for all event emission sites.
     """
 
     metrics_location: dict[str, MetricLocation]
@@ -120,6 +124,7 @@ class GenerationInfo:
     method_signals_location: dict[int, MethodSignalsLocation]
     profile_data: ProfileData
     logs: list[GeneratedLog]
+    evlog: GeneratedEvLog
 
     def encode(self, file_name: str):
         """
@@ -217,10 +222,16 @@ class SignalLogRecord(logging.LogRecordInfo):
     """Amaranth signals that will be used to format the message."""
 
 
-class VerilogLogWrapper(Elaboratable):
+class VerilogDebugWrapper(Elaboratable):
+    """Wraps an elaboratable in order to expose debug information (log records
+    and event emission sites) as named signals locatable in the generated
+    Verilog code."""
+
     def __init__(self, elaboratable: Elaboratable):
         self.elaboratable = elaboratable
         self.records: list[SignalLogRecord] = []
+        self.evlog_records: list[tuple[EmittedEvent, Signal, list[Signal]]] = []
+        self.evlog_triggers: Optional[Signal] = None
 
     def elaborate(self, platform):
         m = Module()
@@ -228,7 +239,7 @@ class VerilogLogWrapper(Elaboratable):
         elaboratable = Fragment.get(self.elaboratable, platform)
         m.submodules.elaboratable = elaboratable
 
-        def to_signal(val: Value | ValueCastable):
+        def to_signal(val: Value | ValueCastable) -> Signal:
             val = Value.cast(val)
             if isinstance(val, Signal):
                 return val
@@ -242,6 +253,17 @@ class VerilogLogWrapper(Elaboratable):
             record_dict["trigger"] = to_signal(record.trigger)
             record_dict["fields"] = tuple(to_signal(val) for val in record.fields)
             self.records.append(SignalLogRecord(**record_dict))
+
+        for emitted in get_emitted_events():
+            trigger = to_signal(emitted.trigger)
+            fields = [to_signal(val) for val in emitted.fields.values()]
+            self.evlog_records.append((emitted, trigger, fields))
+
+        if self.evlog_records:
+            # A packed vector of all event triggers, so that simulators can
+            # check all emission sites with a single signal read per cycle.
+            self.evlog_triggers = Signal(len(self.evlog_records), name="evlog_triggers")
+            m.d.comb += self.evlog_triggers.eq(Cat(trigger for _, trigger, _ in self.evlog_records))
 
         return m
 
@@ -263,6 +285,20 @@ class VerilogLogWrapper(Elaboratable):
 
         return logs
 
+    def collect_evlog(self, name_map: "SignalDict") -> GeneratedEvLog:
+        schema = schema_from_records(emitted for emitted, _, _ in self.evlog_records)
+        site_locations = [
+            EventSiteLocation(
+                trigger=list(get_signal_location(trigger, name_map)),
+                fields=[list(get_signal_location(field, name_map)) for field in fields],
+            )
+            for _, trigger, fields in self.evlog_records
+        ]
+        triggers_location = (
+            list(get_signal_location(self.evlog_triggers, name_map)) if self.evlog_triggers is not None else None
+        )
+        return GeneratedEvLog(schema=schema, site_locations=site_locations, triggers_location=triggers_location)
+
 
 def generate_verilog(
     elaboratable: Elaboratable,
@@ -280,7 +316,7 @@ def generate_verilog(
     elif ports is None:
         raise TypeError("The `generate_verilog()` function requires a `ports=` argument")
 
-    wrapped_elaboratable = VerilogLogWrapper(elaboratable)
+    wrapped_elaboratable = VerilogDebugWrapper(elaboratable)
     design = Fragment.get(wrapped_elaboratable, platform=None).prepare(ports=ports)
 
     if "fixup_vivado_transparent_memories" in enable_hacks:
@@ -299,6 +335,7 @@ def generate_verilog(
         method_signals_location=method_signals,
         profile_data=profile_data,
         logs=wrapped_elaboratable.collect_logs(name_map),
+        evlog=wrapped_elaboratable.collect_evlog(name_map),  # type: ignore
     )
 
     return verilog_text, gen_info


### PR DESCRIPTION
A second take on hardware logging, but this time structured: instead of formatted text messages, the design emits typed events that are captured during simulation into an event log with a stable schema. The log can be saved to a file and processed offline by downstream tools (trace converters, statistics, whatever) without touching the HDL again.

The hardware logging module can be technically migrated to use this instead.