### PR TITLE
Transpose

### DIFF
--- a/test/utils/amaranth_ext/test_data.py
+++ b/test/utils/amaranth_ext/test_data.py
@@ -1,3 +1,5 @@
+from typing import Any, overload
+from amaranth_types import ShapeLike
 from transactron.testing import *
 from transactron.utils.amaranth_ext.data import *
 from amaranth import *
@@ -14,23 +16,64 @@ class TestLayoutKeys:
         assert list(layout_keys(data.FlexibleLayout(10, {0: data.Field(2, 0), "a": data.Field(8, 2)}))) == [0, "a"]
 
 
+@overload
+def mk_const(shape: data.StructLayout) -> dict[str, Any]: ...
+
+
+@overload
+def mk_const(shape: data.ArrayLayout) -> list[Any]: ...
+
+
+@overload
+def mk_const(shape: int) -> int: ...
+
+
+@overload
+def mk_const(shape: ShapeLike) -> Any: ...
+
+
+def mk_const(shape: ShapeLike):
+    if isinstance(shape, data.StructLayout):
+        return {k: mk_const(shape[k].shape) for k in layout_keys(shape)}
+    elif isinstance(shape, data.ArrayLayout):
+        return [mk_const(shape[k].shape) for k in range(shape.length)]
+    elif isinstance(shape, int):
+        return random.randrange(2**shape)
+    else:
+        raise ValueError("incompatible shape")
+
+
+@pytest.mark.parametrize(
+    "layout",
+    [
+        data.ArrayLayout(data.ArrayLayout(4, 3), 3),
+        data.ArrayLayout(data.StructLayout({"a": 2, "b": 3, "c": 4}), 3),
+        data.StructLayout({"a": data.ArrayLayout(2, 3), "b": data.ArrayLayout(3, 3), "c": data.ArrayLayout(4, 3)}),
+        data.StructLayout(
+            {
+                "a": data.StructLayout({"d": 2, "e": 3}),
+                "b": data.StructLayout({"d": 4, "e": 5}),
+                "c": data.StructLayout({"d": 6, "e": 7}),
+            }
+        ),
+    ],
+)
 class TestTranspose(TestCaseWithSimulator):
-    @pytest.mark.parametrize(
-        "layout",
-        [
-            data.ArrayLayout(data.ArrayLayout(4, 3), 3),
-            data.ArrayLayout(data.StructLayout({"a": 2, "b": 3, "c": 4}), 3),
-            data.StructLayout({"a": data.ArrayLayout(2, 3), "b": data.ArrayLayout(3, 3), "c": data.ArrayLayout(4, 3)}),
-            data.StructLayout(
-                {
-                    "a": data.StructLayout({"d": 2, "e": 3}),
-                    "b": data.StructLayout({"d": 4, "e": 5}),
-                    "c": data.StructLayout({"d": 6, "e": 7}),
-                }
-            ),
-        ],
-    )
-    def test_transpose(self, layout: data.Layout):
+    iterations = 20
+
+    def test_transpose_const(self, layout: data.Layout):
+        tr_layout, o_keys, i_keys = transpose_layout_with_keys(layout)
+        for i in range(self.iterations):
+            const = mk_const(layout)
+            val = layout.const(const)
+            tr_val = transpose(val)
+
+            assert tr_val.shape() == tr_layout
+            for o_key in o_keys:
+                for i_key in i_keys:
+                    assert val[o_key][i_key] == tr_val[i_key][o_key]
+
+    def test_transpose_view(self, layout: data.Layout):
         dut = Module()
         sig = Signal(layout)
         tr_layout, o_keys, i_keys = transpose_layout_with_keys(layout)
@@ -42,10 +85,8 @@ class TestTranspose(TestCaseWithSimulator):
         assert layout_keys(tr_layout) == i_keys
         assert layout_keys(tr_layout[i_keys[0]].shape) == o_keys  # type: ignore
 
-        iterations = 20
-
         async def testbench(ctx: TestbenchContext):
-            for i in range(iterations):
+            for i in range(self.iterations):
                 for o_key in o_keys:
                     for i_key in i_keys:
                         ctx.set(sig[o_key][i_key], random.randrange(2 ** sig[o_key][i_key].shape().width))

--- a/test/utils/amaranth_ext/test_data.py
+++ b/test/utils/amaranth_ext/test_data.py
@@ -1,0 +1,55 @@
+from transactron.testing import *
+from transactron.utils.amaranth_ext.data import *
+from amaranth import *
+from amaranth.lib import data
+import pytest
+import random
+
+
+class TestLayoutKeys:
+    def test_layout_keys(self):
+        assert list(layout_keys(data.ArrayLayout(4, 3))) == [0, 1, 2]
+        assert list(layout_keys(data.StructLayout({"a": 1, "b": 2, "c": 3}))) == ["a", "b", "c"]
+        assert list(layout_keys(data.UnionLayout({"a": 1, "b": 2, "c": 3}))) == ["a", "b", "c"]
+        assert list(layout_keys(data.FlexibleLayout(10, {0: data.Field(2, 0), "a": data.Field(8, 2)}))) == [0, "a"]
+
+
+class TestTranspose(TestCaseWithSimulator):
+    @pytest.mark.parametrize(
+        "layout",
+        [
+            data.ArrayLayout(data.ArrayLayout(4, 3), 3),
+            data.ArrayLayout(data.StructLayout({"a": 2, "b": 3, "c": 4}), 3),
+            data.StructLayout({"a": data.ArrayLayout(2, 3), "b": data.ArrayLayout(3, 3), "c": data.ArrayLayout(4, 3)}),
+            data.StructLayout(
+                {
+                    "a": data.StructLayout({"d": 2, "e": 3}),
+                    "b": data.StructLayout({"d": 4, "e": 5}),
+                    "c": data.StructLayout({"d": 6, "e": 7}),
+                }
+            ),
+        ],
+    )
+    def test_transpose(self, layout: data.Layout):
+        dut = Module()
+        sig = Signal(layout)
+        tr_layout, o_keys, i_keys = transpose_layout_with_keys(layout)
+        tr_sig = Signal(tr_layout)
+        dut.d.comb += tr_sig.eq(transpose(sig))
+
+        assert layout_keys(layout) == o_keys
+        assert layout_keys(layout[o_keys[0]].shape) == i_keys  # type: ignore
+        assert layout_keys(tr_layout) == i_keys
+        assert layout_keys(tr_layout[i_keys[0]].shape) == o_keys  # type: ignore
+
+        iterations = 20
+
+        async def testbench(ctx: TestbenchContext):
+            for i in range(iterations):
+                for o_key in o_keys:
+                    for i_key in i_keys:
+                        ctx.set(sig[o_key][i_key], random.randrange(2 ** sig[o_key][i_key].shape().width))
+                        assert ctx.get(sig[o_key][i_key]) == ctx.get(tr_sig[i_key][o_key])
+
+        with self.run_simulation(dut) as sim:
+            sim.add_testbench(testbench)

--- a/test/utils/amaranth_ext/test_data.py
+++ b/test/utils/amaranth_ext/test_data.py
@@ -87,10 +87,12 @@ class TestTranspose(TestCaseWithSimulator):
 
         async def testbench(ctx: TestbenchContext):
             for i in range(self.iterations):
+                const = mk_const(layout)
+                ctx.set(sig, const)
+                tr_const = ctx.get(tr_sig)
                 for o_key in o_keys:
                     for i_key in i_keys:
-                        ctx.set(sig[o_key][i_key], random.randrange(2 ** sig[o_key][i_key].shape().width))
-                        assert ctx.get(sig[o_key][i_key]) == ctx.get(tr_sig[i_key][o_key])
+                        assert const[o_key][i_key] == tr_const[i_key][o_key]
 
         with self.run_simulation(dut) as sim:
             sim.add_testbench(testbench)

--- a/transactron/utils/amaranth_ext/data.py
+++ b/transactron/utils/amaranth_ext/data.py
@@ -1,0 +1,47 @@
+from collections.abc import Callable
+from typing import cast
+from amaranth import Cat, Value
+from amaranth.lib import data
+from amaranth_types import ShapeLike
+
+
+__all__ = ["layout_keys", "transpose"]
+
+
+def layout_keys(layout: data.Layout) -> list[str | int]:
+    if isinstance(layout, data.ArrayLayout):
+        return list(range(layout.length))
+    elif isinstance(layout, (data.StructLayout, data.UnionLayout)):
+        return list(layout.members.keys())
+    elif isinstance(layout, data.FlexibleLayout):
+        return list(layout.fields.keys())
+    else:
+        raise ValueError("Argument is not a layout")
+
+
+def transpose(view: data.View) -> data.View:
+    if not isinstance(view.shape(), (data.ArrayLayout, data.StructLayout)):
+        raise ValueError("Argument layout is not ArrayLayout nor StructLayout")
+    o_keys = layout_keys(view.shape())
+    if not o_keys:
+        raise ValueError("Argument has no fields")
+    if not all(isinstance(view[key], data.View) for key in o_keys):
+        raise ValueError("Fields are not all amaranth.data.Views")
+    if not all(isinstance(view[key].shape(), (data.ArrayLayout, data.StructLayout)) for key in o_keys):
+        raise ValueError("Field layouts are not all ArrayLayouts nor StructLayouts")
+    i_keys = layout_keys(view[o_keys[0]])
+    if not i_keys:
+        raise ValueError("Fields have no fields")
+    if not all(layout_keys(view[key]) == i_keys for key in o_keys[1:]):
+        raise ValueError("Fields have different keys")
+
+    def mk_layout(keys: list[str | int], cont: Callable[[str | int], ShapeLike]) -> data.Layout:
+        if isinstance(keys[0], str):
+            nkeys = cast(list[str], keys)
+            return data.StructLayout({k: cont(k) for k in nkeys})
+        else:
+            return data.ArrayLayout(cont(0), len(keys))
+
+    ret_layout = mk_layout(i_keys, lambda i_key: mk_layout(o_keys, lambda o_key: view[o_key][i_key].shape()))
+    ret_target = Cat(Value.cast(view[o_key][i_key]) for i_key in i_keys for o_key in o_keys)
+    return data.View(ret_layout, ret_target)

--- a/transactron/utils/amaranth_ext/data.py
+++ b/transactron/utils/amaranth_ext/data.py
@@ -5,20 +5,20 @@ from amaranth.lib import data
 from amaranth_types import ShapeLike
 
 
-__all__ = ["layout_keys", "transpose"]
+__all__ = ["layout_keys", "transpose_layout_with_keys", "transpose_layout", "transpose"]
 
 
 @overload
-def layout_keys(layout: data.ArrayLayout) -> Sequence[int]:
-    ...
+def layout_keys(layout: data.ArrayLayout) -> Sequence[int]: ...
+
 
 @overload
-def layout_keys(layout: data.StructLayout | data.UnionLayout) -> Sequence[str]:
-    ...
+def layout_keys(layout: data.StructLayout | data.UnionLayout) -> Sequence[str]: ...
+
 
 @overload
-def layout_keys(layout: data.Layout) -> Sequence[str | int]:
-    ...
+def layout_keys(layout: data.Layout) -> Sequence[str | int]: ...
+
 
 def layout_keys(layout: data.Layout) -> Sequence[str | int]:
     if isinstance(layout, data.ArrayLayout):
@@ -31,29 +31,38 @@ def layout_keys(layout: data.Layout) -> Sequence[str | int]:
         raise ValueError("Argument is not a layout")
 
 
-def transpose(view: data.View) -> data.View:
-    if not isinstance(view.shape(), (data.ArrayLayout, data.StructLayout)):
+def transpose_layout_with_keys(layout: data.Layout):
+    if not isinstance(cast(object, layout), (data.ArrayLayout, data.StructLayout)):
         raise ValueError("Argument layout is not ArrayLayout nor StructLayout")
-    o_keys = layout_keys(view.shape())
+    o_keys = layout_keys(layout)
     if not o_keys:
         raise ValueError("Argument has no fields")
-    if not all(isinstance(view[key], data.View) for key in o_keys):
-        raise ValueError("Fields are not all amaranth.data.Views")
-    if not all(isinstance(view[key].shape(), (data.ArrayLayout, data.StructLayout)) for key in o_keys):
+    i_layouts = {key: layout[key].shape for key in o_keys}
+    if not all(isinstance(i_layouts[key], (data.ArrayLayout, data.StructLayout)) for key in o_keys):
         raise ValueError("Field layouts are not all ArrayLayouts nor StructLayouts")
-    i_keys = layout_keys(view[o_keys[0]])
+    i_layouts = cast(dict[str | int, data.Layout], i_layouts)
+    i_keys = layout_keys(i_layouts[o_keys[0]])
     if not i_keys:
         raise ValueError("Fields have no fields")
-    if not all(layout_keys(view[key]) == i_keys for key in o_keys[1:]):
+    if not all(layout_keys(i_layouts[key]) == i_keys for key in o_keys[1:]):
         raise ValueError("Fields have different keys")
 
-    def mk_layout(keys: list[str | int], cont: Callable[[str | int], ShapeLike]) -> data.Layout:
+    def mk_layout(keys: Sequence[str | int], cont: Callable[[str | int], ShapeLike]) -> data.Layout:
         if isinstance(keys[0], str):
             nkeys = cast(list[str], keys)
             return data.StructLayout({k: cont(k) for k in nkeys})
         else:
             return data.ArrayLayout(cont(0), len(keys))
 
-    ret_layout = mk_layout(i_keys, lambda i_key: mk_layout(o_keys, lambda o_key: view[o_key][i_key].shape()))
+    ret_layout = mk_layout(i_keys, lambda i_key: mk_layout(o_keys, lambda o_key: i_layouts[o_key][i_key].shape))
+    return ret_layout, o_keys, i_keys
+
+
+def transpose_layout(layout: data.Layout) -> data.Layout:
+    return transpose_layout_with_keys(layout)[0]
+
+
+def transpose(view: data.View) -> data.View:
+    ret_layout, o_keys, i_keys = transpose_layout_with_keys(view.shape())
     ret_target = Cat(Value.cast(view[o_key][i_key]) for i_key in i_keys for o_key in o_keys)
     return data.View(ret_layout, ret_target)

--- a/transactron/utils/amaranth_ext/data.py
+++ b/transactron/utils/amaranth_ext/data.py
@@ -120,24 +120,34 @@ def transpose_layout_with_keys(layout: data.Layout) -> tuple[data.Layout, Sequen
     return ret_layout, o_keys, i_keys
 
 
-def transpose(view: data.View) -> data.View:
-    """Transpose a view over a two-level layout.
+@overload
+def transpose(view: data.Const) -> data.Const: ...
 
-    Builds a new `View`, over the layout returned by `transpose_layout`, whose
-    contents are the same as `view` but with the outer and inner levels swapped,
-    so that ``transpose(view)[i_key][o_key]`` is equal to ``view[o_key][i_key]``
-    for every valid pair of keys.
+
+@overload
+def transpose(view: data.View) -> data.View: ...
+
+
+def transpose(view: data.View | data.Const) -> data.View | data.Const:
+    """Transpose a view or constant over a two-level layout.
+
+    Builds a new `View` or `Const` (matching the type of `view`), over the layout
+    returned by `transpose_layout`, whose contents are the same as `view` but with
+    the outer and inner levels swapped, so that ``transpose(view)[i_key][o_key]``
+    is equal to ``view[o_key][i_key]`` for every valid pair of keys.
 
     Parameters
     ----------
-    view : data.View
-        The view to transpose. Its shape must satisfy the requirements of
-        `transpose_layout`.
+    view : data.View | data.Const
+        The view or constant to transpose. Its shape must satisfy the requirements
+        of `transpose_layout`.
 
     Returns
     -------
-    data.View
-        A view of the same underlying value, over the transposed layout.
+    data.View | data.Const
+        A `Const` with the same value as `view`, if `view` is a `data.Const`;
+        otherwise a `View` of the same underlying value; in both cases over the
+        transposed layout.
 
     Raises
     ------
@@ -145,5 +155,7 @@ def transpose(view: data.View) -> data.View:
         See `transpose_layout`.
     """
     ret_layout, o_keys, i_keys = transpose_layout_with_keys(view.shape())
+    if isinstance(view, data.Const):
+        return ret_layout.const({i_key: {o_key: view[o_key][i_key] for o_key in o_keys} for i_key in i_keys})
     ret_target = Cat(Value.cast(view[o_key][i_key]) for i_key in i_keys for o_key in o_keys)
     return data.View(ret_layout, ret_target)

--- a/transactron/utils/amaranth_ext/data.py
+++ b/transactron/utils/amaranth_ext/data.py
@@ -145,9 +145,8 @@ def transpose(view: data.View | data.Const) -> data.View | data.Const:
     Returns
     -------
     data.View | data.Const
-        A `Const` with the same value as `view`, if `view` is a `data.Const`;
-        otherwise a `View` of the same underlying value; in both cases over the
-        transposed layout.
+        Transposed `Const`, if `view` is a `data.Const`, otherwise transposed
+        `View`; over transposed layout.
 
     Raises
     ------

--- a/transactron/utils/amaranth_ext/data.py
+++ b/transactron/utils/amaranth_ext/data.py
@@ -5,7 +5,7 @@ from amaranth.lib import data
 from amaranth_types import ShapeLike
 
 
-__all__ = ["layout_keys", "transpose_layout_with_keys", "transpose_layout", "transpose"]
+__all__ = ["layout_keys", "transpose_layout", "transpose_layout_with_keys", "transpose"]
 
 
 @overload
@@ -21,17 +21,79 @@ def layout_keys(layout: data.Layout) -> Sequence[str | int]: ...
 
 
 def layout_keys(layout: data.Layout) -> Sequence[str | int]:
-    if isinstance(layout, data.ArrayLayout):
-        return list(range(layout.length))
-    elif isinstance(layout, (data.StructLayout, data.UnionLayout)):
-        return list(layout.members.keys())
-    elif isinstance(layout, data.FlexibleLayout):
-        return list(layout.fields.keys())
-    else:
-        raise ValueError("Argument is not a layout")
+    """Get the field keys of a layout, in order.
+
+    Parameters
+    ----------
+    layout : data.Layout
+        The layout to get the keys of. If it is an `ArrayLayout`, the keys are
+        the field indices (`int`); if it is a `StructLayout` or `UnionLayout`,
+        the keys are the field names (`str`).
+
+    Returns
+    -------
+    Sequence[str | int]
+        The keys of `layout`, in the order in which they are defined.
+    """
+    return [k for k, _ in layout]
 
 
-def transpose_layout_with_keys(layout: data.Layout):
+def transpose_layout(layout: data.Layout) -> data.Layout:
+    """Transpose a two-level layout.
+
+    `layout` is expected to be an `ArrayLayout` or `StructLayout` whose every field
+    is itself an `ArrayLayout` or `StructLayout`, with all of the fields sharing the
+    same set of inner keys. The transposition swaps the outer and inner levels, so
+    that a value which was addressed as ``value[o_key][i_key]`` in the original
+    layout is addressed as ``transposed[i_key][o_key]`` in the resulting layout.
+
+    Parameters
+    ----------
+    layout : data.Layout
+        The layout to transpose. Must be an `ArrayLayout` or `StructLayout` whose
+        fields are all `ArrayLayout`\\s or `StructLayout`\\s sharing identical keys.
+
+    Returns
+    -------
+    data.Layout
+        The transposed layout.
+
+    Raises
+    ------
+    ValueError
+        If `layout` is not an `ArrayLayout` or `StructLayout`; if it has no fields;
+        if its fields are not all `ArrayLayout`\\s or `StructLayout`\\s; if its
+        fields have no keys; or if its fields do not all share the same keys.
+    """
+    return transpose_layout_with_keys(layout)[0]
+
+
+def transpose_layout_with_keys(layout: data.Layout) -> tuple[data.Layout, Sequence[str | int], Sequence[str | int]]:
+    """Extended version of `transpose_layout` that also returns the keys of both levels.
+
+    Behaves exactly like `transpose_layout`, but additionally returns the outer and
+    inner keys of `layout` that were used to perform the transposition, so that
+    callers can address the original fields without recomputing them.
+
+    Parameters
+    ----------
+    layout : data.Layout
+        The layout to transpose. See `transpose_layout` for the requirements it
+        must satisfy.
+
+    Returns
+    -------
+    tuple[data.Layout, Sequence[str | int], Sequence[str | int]]
+        A tuple ``(ret_layout, o_keys, i_keys)``, where `ret_layout` is the layout
+        that would be returned by `transpose_layout`, `o_keys` are the outer
+        (top-level) keys of `layout`, and `i_keys` are the inner keys shared by
+        all of its fields.
+
+    Raises
+    ------
+    ValueError
+        See `transpose_layout`.
+    """
     if not isinstance(cast(object, layout), (data.ArrayLayout, data.StructLayout)):
         raise ValueError("Argument layout is not ArrayLayout nor StructLayout")
     o_keys = layout_keys(layout)
@@ -58,11 +120,30 @@ def transpose_layout_with_keys(layout: data.Layout):
     return ret_layout, o_keys, i_keys
 
 
-def transpose_layout(layout: data.Layout) -> data.Layout:
-    return transpose_layout_with_keys(layout)[0]
-
-
 def transpose(view: data.View) -> data.View:
+    """Transpose a view over a two-level layout.
+
+    Builds a new `View`, over the layout returned by `transpose_layout`, whose
+    contents are the same as `view` but with the outer and inner levels swapped,
+    so that ``transpose(view)[i_key][o_key]`` is equal to ``view[o_key][i_key]``
+    for every valid pair of keys.
+
+    Parameters
+    ----------
+    view : data.View
+        The view to transpose. Its shape must satisfy the requirements of
+        `transpose_layout`.
+
+    Returns
+    -------
+    data.View
+        A view of the same underlying value, over the transposed layout.
+
+    Raises
+    ------
+    ValueError
+        See `transpose_layout`.
+    """
     ret_layout, o_keys, i_keys = transpose_layout_with_keys(view.shape())
     ret_target = Cat(Value.cast(view[o_key][i_key]) for i_key in i_keys for o_key in o_keys)
     return data.View(ret_layout, ret_target)

--- a/transactron/utils/amaranth_ext/data.py
+++ b/transactron/utils/amaranth_ext/data.py
@@ -1,5 +1,5 @@
-from collections.abc import Callable
-from typing import cast
+from collections.abc import Callable, Sequence
+from typing import cast, overload
 from amaranth import Cat, Value
 from amaranth.lib import data
 from amaranth_types import ShapeLike
@@ -8,7 +8,19 @@ from amaranth_types import ShapeLike
 __all__ = ["layout_keys", "transpose"]
 
 
-def layout_keys(layout: data.Layout) -> list[str | int]:
+@overload
+def layout_keys(layout: data.ArrayLayout) -> Sequence[int]:
+    ...
+
+@overload
+def layout_keys(layout: data.StructLayout | data.UnionLayout) -> Sequence[str]:
+    ...
+
+@overload
+def layout_keys(layout: data.Layout) -> Sequence[str | int]:
+    ...
+
+def layout_keys(layout: data.Layout) -> Sequence[str | int]:
     if isinstance(layout, data.ArrayLayout):
         return list(range(layout.length))
     elif isinstance(layout, (data.StructLayout, data.UnionLayout)):


### PR DESCRIPTION
This PR adds the `transpose` function, which swaps two layers of `data.View`. Intended use: superscalarity in pipeline builder.

TODO:
- [x] Docs
- [x] Test