### PR TITLE
Update Sphinx, some doc ref changes

### DIFF
--- a/docs/evlog.md
+++ b/docs/evlog.md
@@ -91,7 +91,7 @@ $ transactron-evlog -m coreblocks.telemetry -f "ftq" -c 8:10 events.jsonl
 
 `--schema` prints a summary of the emission sites instead; `-x`/`-d` force hex/decimal field values.
 
-Consumers subclass {py:class}`~transactron.evlog.consumer.EventConsumer` and declare one handler per event type with {py:func}`~transactron.evlog.consumer.handles`; dispatch is keyed by the registered event name:
+Consumers subclass {py:class}`~transactron.evlog.consumer.EventConsumer` and declare one handler per event type with {py:deco}`~transactron.evlog.consumer.handles`; dispatch is keyed by the registered event name:
 
 ```python
 from transactron.evlog import DecodedEvent, EventConsumer, EventLogReader, handles

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -205,7 +205,7 @@ The `push` method will insert a new element to the stack, while `pop_set_top` wi
 These two methods take a single parameter `val` and return nothing.
 
 The methods are defined inside `elaborate` using the {py:class}`~transactron.lib.stack.Stack` component and two additional registers, `top` and `nonempty`.
-Methods are defined using {py:class}`~transactron.core.sugar.def_method` decorator syntax.
+Methods are defined using {py:deco}`~transactron.core.sugar.def_method` decorator syntax.
 The method definition is written using Python `def` function syntax.
 It works much like the `body` context manager used for defining transactions -- the Python code inside the definition is evaluated exactly once.
 Method inputs are passed as parameters, while the result is provided using `return` as a `dict`.

--- a/docs/pipeline-guide.md
+++ b/docs/pipeline-guide.md
@@ -1,6 +1,6 @@
 # Pipeline Builder
 
-The Pipeline Builder is a helper for constructing transactional pipelines in Transactron.
+The {py:class}`Pipeline Builder <transactron.lib.pipeline.PipelineBuilder>` is a helper for constructing transactional pipelines in Transactron.
 It lets you combine external methods, function-based stages, and method calls into a single flow with automatic data forwarding.
 
 ## Overview
@@ -20,16 +20,16 @@ Main use cases:
 ### Node Types
 
 Pipelines can contain three node kinds:
-1. `add_external(method, ...)`: pipeline provides (defines) a method body.
-2. `call_method(method, ...)`: pipeline calls an existing method.
-3. `@stage(...)`: function-based stage converted to a transactional method.
+1. {py:meth}`~transactron.lib.pipeline.PipelineBuilder.add_external`: pipeline provides (defines) a method body.
+2. {py:meth}`~transactron.lib.pipeline.PipelineBuilder.call_method`: pipeline calls an existing method.
+3. {py:deco}`~transactron.lib.pipeline.PipelineBuilder.stage`: function-based stage converted to a transactional method.
 
 ### Live Signals
 
 At each position in the pipeline, a set of live signals is tracked.
 Stages can consume any currently live signals they declare as inputs and add/overwrite outputs.
 
-`PipelineBuilder.get_live_signals()` can be used to inspect this state before elaboration.
+{py:meth}`~transactron.lib.pipeline.PipelineBuilder.get_live_signals` can be used to inspect this state before elaboration.
 
 ## Happens-Before Semantics
 
@@ -122,7 +122,7 @@ Current implementation uses `BasicFifo` internally.
 
 ## Example: Pipelined Multiplier
 
-The following complete example demonstrates a multi-stage arithmetic pipeline using `PipelineBuilder`:
+The following complete example demonstrates a multi-stage arithmetic pipeline using {py:class}`~transactron.lib.pipeline.PipelineBuilder`:
 
 ```{literalinclude} _code/pipelined_mult.py
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,11 +49,11 @@ test = [
     "hypothesis == 6.99.6",
 ]
 docs = [
-    "Sphinx == 8.2.3",
-    "sphinx-rtd-theme == 3.0.2",
-    "myst-parser == 4.0.1",
-    "numpydoc == 1.5.0",
-    "sphinxcontrib-mermaid == 0.8.1",
+    "Sphinx == 9.1.0",
+    "sphinx-rtd-theme == 3.1.0",
+    "myst-parser == 5.1.0",
+    "numpydoc == 1.10.0",
+    "sphinxcontrib-mermaid == 2.0.2",
 ]
 dev = [
     {include-group = "lint"},

--- a/transactron/evlog/log.py
+++ b/transactron/evlog/log.py
@@ -18,7 +18,7 @@ __all__ = [
 ]
 
 
-RawEvent = tuple[int, int, list[int]]
+type RawEvent = tuple[int, int, list[int]]
 """A raw event record: (cycle, site index, dynamic field values in schema order)."""
 
 

--- a/transactron/evlog/schema.py
+++ b/transactron/evlog/schema.py
@@ -1,6 +1,6 @@
 from collections.abc import Iterable
 from dataclasses import dataclass, field
-from typing import Any, Optional, TypeAlias
+from typing import Any, Optional
 
 from dataclasses_json import dataclass_json
 
@@ -20,7 +20,7 @@ __all__ = [
 ]
 
 
-SignalHandle: TypeAlias = list[str]
+type SignalHandle = list[str]
 """The location of a signal in generated Verilog code: a list of Verilog
 identifiers denoting a path of module names with the signal name at the end."""
 


### PR DESCRIPTION
Turns out `py:deco` works with tilde references in Sphinx 9 (https://github.com/sphinx-doc/sphinx/issues/13528), thus the update.

Edit: plus a tiny change to make docs build without errors.