### PR TITLE
Set reset_less=True on signals that does not need initialization

### DIFF
--- a/transactron/lib/connectors.py
+++ b/transactron/lib/connectors.py
@@ -126,7 +126,7 @@ class Forwarder(Elaboratable):
     def elaborate(self, platform):
         m = TModule()
 
-        reg = Signal.like(self.read.data_out)
+        reg = Signal.like(self.read.data_out, reset_less=True)
         reg_valid = Signal()
         read_value = Signal.like(self.read.data_out)
 
@@ -201,7 +201,7 @@ class Pipe(Elaboratable):
     def elaborate(self, platform):
         m = TModule()
 
-        reg = Signal.like(self.read.data_out)
+        reg = Signal.like(self.read.data_out, reset_less=True)
         reg_valid = Signal()
 
         self.read.schedule_before(self.write)  # to avoid combinational loops


### PR DESCRIPTION
This can save circuitry and routing constraints for at least FPGAs.

For one of my design that uses many pipeline stages, this save a few thousand ns of total routing delays and reduced the worst timing by up to 0.5ns.

I've only looked in this one file and didn't check anywhere else if any other signals could use reset_less as well.
I've also noticed that `Pipe` appears to have a `head` member that does not seem to be used anywhere.
