### PR TITLE
Resetless in storage

### DIFF
--- a/transactron/lib/storage.py
+++ b/transactron/lib/storage.py
@@ -114,12 +114,12 @@ class MemoryBank(Elaboratable):
         # read_output_next[i] is the value of the memory cell read_output_addr[i] in the next clock cycle
         read_output_valid = [Signal() for _ in range(self.reads_ports)]
         read_output_next = [Signal(self.shape) for _ in range(self.reads_ports)]
-        read_output_addr = [Signal(range(self.depth)) for _ in range(self.reads_ports)]
+        read_output_addr = [Signal(range(self.depth), reset_less=True) for _ in range(self.reads_ports)]
 
         overflow_valid = [Signal() for _ in range(self.reads_ports)]
-        overflow_data = [Signal(self.shape) for _ in range(self.reads_ports)]
+        overflow_data = [Signal(self.shape, reset_less=True) for _ in range(self.reads_ports)]
         overflow_next = [Signal(self.shape) for _ in range(self.reads_ports)]
-        overflow_addr = [Signal(range(self.depth)) for _ in range(self.reads_ports)]
+        overflow_addr = [Signal(range(self.depth), reset_less=True) for _ in range(self.reads_ports)]
 
         for i in range(self.reads_ports):
             if self.read_on_resp:
@@ -259,9 +259,14 @@ class ContentAddressableMemory(Elaboratable):
         m = TModule()
 
         address_array = Array(
-            [Signal(self.address_layout, name=f"address_array_{i}") for i in range(self.entries_number)]
+            [
+                Signal(self.address_layout, name=f"address_array_{i}", reset_less=True)
+                for i in range(self.entries_number)
+            ]
         )
-        data_array = Array([Signal(self.data_layout, name=f"data_array_{i}") for i in range(self.entries_number)])
+        data_array = Array(
+            [Signal(self.data_layout, name=f"data_array_{i}", reset_less=True) for i in range(self.entries_number)]
+        )
         valids = Signal(self.entries_number, name="valids")
 
         m.submodules.encoder_read = encoder_read = MultiPriorityEncoder(self.entries_number, 1)

--- a/transactron/utils/amaranth_ext/memory.py
+++ b/transactron/utils/amaranth_ext/memory.py
@@ -209,8 +209,8 @@ class MultiportXORMemory(BaseMultiportMemory):
         write_xors = [Value.cast(0) for _ in self.write_ports]
         read_xors = [Value.cast(0) for _ in self.read_ports]
 
-        write_regs_addr = [Signal(range(self.depth)) for _ in self.write_ports]
-        write_regs_data = [Signal(self.shape) for _ in self.write_ports]
+        write_regs_addr = [Signal(range(self.depth), reset_less=True) for _ in self.write_ports]
+        write_regs_data = [Signal(self.shape, reset_less=True) for _ in self.write_ports]
         read_en_bypass = [Signal() for _ in self.read_ports]
 
         # feedback ports
@@ -260,8 +260,8 @@ class MultiportXORMemory(BaseMultiportMemory):
 
             m.d.sync += [r_write_port.addr.eq(write_port.addr), r_write_port.en.eq(write_port.en)]
 
-            write_addr_bypass = Signal(range(self.depth))
-            write_data_bypass = Signal(self.shape)
+            write_addr_bypass = Signal(range(self.depth), reset_less=True)
+            write_data_bypass = Signal(self.shape, reset_less=True)
             write_en_bypass = Signal()
             m.d.sync += [
                 write_addr_bypass.eq(write_regs_addr[index]),
@@ -270,7 +270,7 @@ class MultiportXORMemory(BaseMultiportMemory):
             ]
 
             for idx, port in enumerate(r_read_ports):
-                read_addr_bypass = Signal(range(self.depth))
+                read_addr_bypass = Signal(range(self.depth), reset_less=True)
 
                 m.d.sync += [
                     read_addr_bypass.eq(self.read_ports[idx].addr),
@@ -295,7 +295,7 @@ class MultiportXORMemory(BaseMultiportMemory):
                 m.d.comb += [port.addr.eq(self.read_ports[idx].addr), port.en.eq(self.read_ports[idx].en)]
 
         for index, port in enumerate(self.read_ports):
-            sync_data = Signal.like(port.data)
+            sync_data = Signal.like(port.data, reset_less=True)
             m.d.sync += sync_data.eq(port.data)
             m.d.comb += [port.data.eq(Mux(read_en_bypass[index], read_xors[index], sync_data))]
 
@@ -327,15 +327,15 @@ class OneHotCodedILVT(BaseMultiportMemory):
         if Shape(len(self.write_ports)) != self.shape:
             raise IncorrectWritePortNumber("Number of write ports not equal to ILVT's shape.")
 
-        write_addr_sync = [Signal(port.addr.shape()) for port in self.write_ports]
+        write_addr_sync = [Signal(port.addr.shape(), reset_less=True) for port in self.write_ports]
         write_en_sync = [Signal() for _ in self.write_ports]
-        write_data_sync = [Signal(self.shape) for _ in self.write_ports]
+        write_data_sync = [Signal(self.shape, reset_less=True) for _ in self.write_ports]
 
-        write_addr_bypass = [Signal(port.addr.shape()) for port in self.write_ports]
+        write_addr_bypass = [Signal(port.addr.shape(), reset_less=True) for port in self.write_ports]
         write_en_bypass = [Signal() for _ in self.write_ports]
-        write_data_bypass = [Signal(self.shape) for _ in self.write_ports]
+        write_data_bypass = [Signal(self.shape, reset_less=True) for _ in self.write_ports]
 
-        read_addr_bypass = [Signal(port.addr.shape()) for port in self.read_ports]
+        read_addr_bypass = [Signal(port.addr.shape(), reset_less=True) for port in self.read_ports]
         read_en_bypass = [Signal() for _ in self.read_ports]
 
         bypassed_data = [[Signal(len(self.write_ports) - 1) for _ in self.write_ports] for _ in self.read_ports]
@@ -485,8 +485,8 @@ class MultiportILVTMemory(BaseMultiportMemory):
         ilvt_write_ports = [ilvt.write_port() for _ in self.write_ports]
         ilvt_read_ports = [ilvt.read_port() for _ in self.read_ports]
 
-        write_addr_bypass = [Signal(port.addr.shape()) for port in self.write_ports]
-        write_data_bypass = [Signal(self.shape) for _ in self.write_ports]
+        write_addr_bypass = [Signal(port.addr.shape(), reset_less=True) for port in self.write_ports]
+        write_data_bypass = [Signal(self.shape, reset_less=True) for _ in self.write_ports]
         write_en_bypass = [Signal(port.en.shape()) for port in self.write_ports]
 
         m.d.sync += [write_addr_bypass[index].eq(port.addr) for index, port in enumerate(self.write_ports)]
@@ -527,7 +527,7 @@ class MultiportILVTMemory(BaseMultiportMemory):
             m.d.comb += [ilvt_read_ports[index].addr.eq(read_port.addr), ilvt_read_ports[index].en.eq(read_port.en)]
 
             read_en_bypass = Signal()
-            read_addr_bypass = Signal(self.shape)
+            read_addr_bypass = Signal(self.shape, reset_less=True)
 
             m.d.sync += [read_en_bypass.eq(read_port.en), read_addr_bypass.eq(read_port.addr)]
 
@@ -552,7 +552,7 @@ class MultiportILVTMemory(BaseMultiportMemory):
             ]
             new_data = OneHotMux.create(m, mux_inputs, bank_data)
 
-            sync_data = Signal.like(read_port.data)
+            sync_data = Signal.like(read_port.data, reset_less=True)
             m.d.sync += sync_data.eq(read_port.data)
             m.d.comb += [read_port.data.eq(Mux(read_en_bypass, new_data, sync_data))]
 


### PR DESCRIPTION
Following #205, `reset_less` is added to appropriate registers in `lib.storage` and `utils.amaranth_ext.memory`.