### PR TITLE
hierarchical runnable signal

### DIFF
--- a/transactron/core/body.py
+++ b/transactron/core/body.py
@@ -57,6 +57,7 @@ class Body(TransactionBase["Body"]):
         self.name = name
         self.owner = owner
         self.ready = Signal(name=self.owned_name + "_ready")
+        self.allocatable = Signal(name=self.owned_name + "_allocatable")
         self.runnable = Signal(name=self.owned_name + "_runnable")
         self.run = Signal(name=self.owned_name + "_run")
         self.data_in: MethodStruct = Signal(from_method_layout(i), name=self.owned_name + "_data_in")
@@ -82,10 +83,10 @@ class Body(TransactionBase["Body"]):
             if any(len(ctrl_path.path) > len(self.ctrl_path.path) + 1 for ctrl_path, _, _ in calls)
         }
 
-    def _validate_arguments(self, en: Value, arg_rec: MethodStruct) -> ValueLike:
+    def _validate_arguments(self, arg_rec: Callable[[], MethodStruct]) -> ValueLike:
         if self.validate_arguments is not None:
-            return self.ready & (~en | method_def_helper(self, self.validate_arguments, arg_rec))
-        return self.ready
+            return method_def_helper(self, self.validate_arguments, arg_rec())
+        return C(1)
 
     @contextmanager
     def context(self, m: TModule) -> Iterator["Body"]:

--- a/transactron/core/manager.py
+++ b/transactron/core/manager.py
@@ -504,33 +504,35 @@ class TransactionManager(Elaboratable):
         # Signals assigned here because `method.provide` sometimes needs to be used without a TModule.
         # Unfortunately, assignments across modules seem to cause a performance hit in pysim.
         provided_methods = DependencyContext.get().get_dependency(ProvidedMethodsKey())
-        for method in chain(provided_methods):
+        for method in provided_methods:
             m.d.comb += method.ready.eq(method._body.ready)
+            m.d.comb += method.allocatable.eq(method._body.allocatable)
+            m.d.comb += method.runnable.eq(method._body.runnable)
             m.d.comb += method.run.eq(method._body.run)
             m.d.comb += method.data_in.eq(method._body.data_in)
             m.d.comb += method.data_out.eq(method._body.data_out)
 
-        for transaction in method_map.transactions:
-
-            def validate_args_for_method(method: MBody):
-                calls = method_map.info_by_call[(transaction, method)]
-                combined = OneHotMux.create(m, [(call.enable, call.arg) for call in calls])
-                return method._validate_arguments(Cat(call.enable for call in calls).any(), combined)
-
-            runnable_terms = [
-                validate_args_for_method(method) for method in method_map.methods_by_transaction[transaction]
-            ]
-            runnable_terms.extend(
-                dep.run for body in method_map.ready_for_transaction(transaction) for dep in ready_dependencies[body]
+        for body in method_map.methods_and_transactions:
+            # body is allocatable iif it is ready, all its ready dependencies are running
+            # and all its called methods are allocatable
+            m.d.comb += body.allocatable.eq(
+                body.ready
+                & Cat(dep.run for dep in ready_dependencies[body]).all()
+                & Cat(method.allocatable for method in body.method_calls.keys()).all()
             )
-            m.d.comb += transaction.runnable.eq(Cat(runnable_terms).all())
 
-        for method, transactions in method_map.transactions_by_method.items():
-            granted = Cat(
-                transaction.run & Cat(call.enable for call in method_map.info_by_call[(transaction, method)]).any()
-                for transaction in transactions
-            )
-            m.d.comb += method.run.eq(granted.any())
+            # body is runnable iif it is allocatable and all would-be called methods
+            # have arguments valid and are runnable.
+            args_valid = []
+            for method, calls in body.method_calls.items():
+                called = Cat(enable for _, _, enable in calls).any()
+
+                def get_arg():
+                    return OneHotMux.create(m, [(enable, arg) for _, arg, enable in calls])
+
+                args_valid.append(~called | (method.runnable & method._body._validate_arguments(get_arg)))
+
+            m.d.comb += body.runnable.eq(body.allocatable & Cat(args_valid).all())
 
         ccs = _graph_ccs(cgr)
         (method_args, method_runs) = self._method_calls(m, method_map)
@@ -539,6 +541,7 @@ class TransactionManager(Elaboratable):
             if method.single_caller and len(method_args[method]) > 1:
                 raise RuntimeError(f"Single-caller method '{method.name}' {method.src_loc} called more than once")
             runs = Cat(method_runs[method])
+            m.d.comb += method.run.eq(runs.any())
             m.d.comb += assign(method.data_in, method.combiner(m, method_args[method], runs), fields=AssignType.ALL)
 
         m.submodules._transactron_schedulers = ModuleConnector(

--- a/transactron/core/manager.py
+++ b/transactron/core/manager.py
@@ -512,6 +512,25 @@ class TransactionManager(Elaboratable):
             m.d.comb += method.data_in.eq(method._body.data_in)
             m.d.comb += method.data_out.eq(method._body.data_out)
 
+        trivial_args_valid = set()
+
+        to_check = {method for method in method_map.methods if method.validate_arguments is None}
+        while to_check:
+            method = to_check.pop()
+            if method in trivial_args_valid:
+                continue
+
+            if all(callee in trivial_args_valid for callee in method.method_calls.keys()):
+                trivial_args_valid.add(method)
+
+                for caller in method_map.method_parents[method]:
+                    if (
+                        caller.validate_arguments is not None
+                        and caller not in trivial_args_valid
+                        and caller in method_map.methods
+                    ):
+                        to_check.add(MBody(caller))
+
         for body in method_map.methods_and_transactions:
             # body is allocatable iif it is ready, all its ready dependencies are running
             # and all its called methods are allocatable
@@ -525,6 +544,9 @@ class TransactionManager(Elaboratable):
             # have arguments valid and are runnable.
             args_valid = []
             for method, calls in body.method_calls.items():
+                if method in trivial_args_valid:
+                    continue
+
                 called = Cat(enable for _, _, enable in calls).any()
 
                 def get_arg():

--- a/transactron/core/method.py
+++ b/transactron/core/method.py
@@ -62,6 +62,11 @@ class Method(TransactionBase["Transaction | Method"]):
     ready: Signal, in
         Signals that the method is ready to run in the current cycle.
         Typically defined by calling `body`.
+    allocatable: Signal, out
+        Signals that the method and all used methods are ready.
+    runnable: Signal, out
+        Signals that the transaction is allocatable and all would-be called methods
+        have arguments valid and are runnable.
     run: Signal, out
         Signals that the method is called in the current cycle by some
         `Transaction`. Defined by the `TransactionManager`.
@@ -97,6 +102,8 @@ class Method(TransactionBase["Transaction | Method"]):
         self.owner, owner_name = get_caller_class_name(default="$method")
         self.name = name or tracer.get_var_name(depth=2, default=owner_name)
         self.ready = Signal(name=self.owned_name + "_ready")
+        self.allocatable = Signal(name=self.owned_name + "_allocatable")
+        self.runnable = Signal(name=self.owned_name + "_runnable")
         self.run = Signal(name=self.owned_name + "_run")
         self.data_in: MethodStruct = Signal(from_method_layout(i), name=self.owned_name + "_data_in")
         self.data_out: MethodStruct = Signal(from_method_layout(o), name=self.owned_name + "_data_out")
@@ -250,6 +257,8 @@ class Method(TransactionBase["Transaction | Method"]):
         # - The waveforms will be available in the module which defined the method.
         # - This simulates faster in pysim.
         m.d.top_comb += self.ready.eq(body.ready)
+        m.d.top_comb += self.allocatable.eq(body.allocatable)
+        m.d.top_comb += self.runnable.eq(body.runnable)
         m.d.top_comb += self.run.eq(body.run)
         m.d.top_comb += self.data_in.eq(body.data_in)
         m.d.top_comb += self.data_out.eq(body.data_out)
@@ -330,7 +339,7 @@ class Method(TransactionBase["Transaction | Method"]):
         return "(method {})".format(self.name)
 
     def debug_signals(self) -> ValueBundle:
-        return [self.ready, self.run, self.data_in, self.data_out]
+        return [self.ready, self.allocatable, self.runnable, self.run, self.data_in, self.data_out]
 
 
 class Methods(Sequence[Method]):

--- a/transactron/core/transaction.py
+++ b/transactron/core/transaction.py
@@ -53,8 +53,11 @@ class Transaction(TransactionBase["Transaction | Method"]):
     ready: Signal, in
         Signals that the transaction wants to run. If omitted, the transaction
         is always ready. Defined in the constructor.
+    allocatable: Signal, out
+        Signals that the transaction and all used methods are ready.
     runnable: Signal, out
-        Signals that all used methods are ready.
+        Signals that the transaction is allocatable and all would-be called methods
+        have arguments valid and are runnable.
     run: Signal, out
         Signals that the transaction is run by the `TransactionManager`.
     """
@@ -78,7 +81,9 @@ class Transaction(TransactionBase["Transaction | Method"]):
         self.owner, owner_name = get_caller_class_name(default="$transaction")
         self.name = name or tracer.get_var_name(depth=2, default=owner_name)
         DependencyContext.get().add_dependency(TransactionsKey(), self)
+
         self.ready = Signal(name=self.owned_name + "_ready")
+        self.allocatable = Signal(name=self.owned_name + "_allocatable")
         self.runnable = Signal(name=self.owned_name + "_runnable")
         self.run = Signal(name=self.owned_name + "_run")
 
@@ -95,6 +100,7 @@ class Transaction(TransactionBase["Transaction | Method"]):
             raise ValueError(f"Transaction body {value.name} {value.src_loc} has invalid interface")
         self._body_ptr = value
         m.d.top_comb += self.ready.eq(value.ready)
+        m.d.top_comb += self.allocatable.eq(value.allocatable)
         m.d.top_comb += self.runnable.eq(value.runnable)
         m.d.top_comb += self.run.eq(value.run)
 
@@ -136,4 +142,4 @@ class Transaction(TransactionBase["Transaction | Method"]):
         return "(transaction {})".format(self.name)
 
     def debug_signals(self) -> ValueBundle:
-        return [self.ready, self.runnable, self.run]
+        return [self.ready, self.allocatable, self.runnable, self.run]


### PR DESCRIPTION
Towards further unification of transactions and methods.

Changes:
- introduces `allocatable` signal which tells if all called methods are ready
-  fixes the documentation for `runnable` signal as it didn't acknowledge the `validate_arguments`. It is now also on the `Method`
- `validate_arguments` checkers are now per call site rather than transaction - due to it's semantics all uses that would have different validity on the methods within would cause comb cycles. As such only a single arg checker is needed per call site.
- `run` signal for methods is also hierarchical

Related issues:
closes #166