### PR TITLE
Coreblocks synth smoke test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,3 +68,37 @@ jobs:
 
       - name: Run pre-commit checks
         run: pre-commit run --all-files --show-diff-on-failure
+  
+  coreblocks-synth-smoke-test:
+    name: Coreblocks synthesis smoke test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          path: transactron
+
+      - name: Checkout Coreblocks
+        uses: actions/checkout@v6
+        with:
+          repository: 'kuznia-rdzeni/coreblocks'
+          path: coreblocks
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+          cache: 'pip'
+          cache-dependency-path: |
+            coreblocks/pyproject.toml
+            transactron/pyproject.toml
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip3 install ./coreblocks
+          pip3 install ./transactron
+
+      - name: Generate Verilog for full core
+        run: coreblocks -c full

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Run pre-commit checks
         run: pre-commit run --all-files --show-diff-on-failure
-  
+
   coreblocks-synth-smoke-test:
     name: Coreblocks synthesis smoke test
     runs-on: ubuntu-latest


### PR DESCRIPTION
A common oopsie when modifying Transactron is making Coreblocks no longer synthesize (e.g. by introducing a combinational loop or some other unintentional incompatibility). This simple workflow is supposed to check for that automatically.