### PR TITLE
Handle types better in evlog consumer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ testing = [
 [dependency-groups]
 lint = [
     "pyright == 1.1.393",
-    "flake8 == 7.0.0",
+    "flake8 == 7.3.0",
     "black == 24.4.2",
     "pep8-naming == 0.13.3",
     "pre-commit == 2.16.0",

--- a/test/evlog/test_evlog.py
+++ b/test/evlog/test_evlog.py
@@ -212,7 +212,7 @@ class TestEventConsumer:
                 self.unhandled: list[DecodedEvent] = []
 
             @handles(InsnStart)
-            def on_start(self, rec: DecodedEvent):
+            def on_start(self, rec: DecodedEvent[InsnStart]):
                 self.seen.append((rec.cycle, rec.event))
 
             def on_unhandled(self, rec: DecodedEvent):
@@ -227,12 +227,12 @@ class TestEventConsumer:
     def test_handler_inheritance(self):
         class Base(EventConsumer):
             @handles(InsnStart)
-            def on_start(self, rec: DecodedEvent):
+            def on_start(self, rec: DecodedEvent[InsnStart]):
                 pass
 
         class Derived(Base):
             @handles(InsnDone)
-            def on_done(self, rec: DecodedEvent):
+            def on_done(self, rec: DecodedEvent[InsnDone]):
                 pass
 
         assert Base._handlers == {"test.insn_start": "on_start"}

--- a/test/lib/test_dependency_key.py
+++ b/test/lib/test_dependency_key.py
@@ -141,7 +141,6 @@ class TestDependencyKey(TestCaseWithSimulator):
             pass
 
     def test_key_cache(self):
-        global combine_calls
         dm = DependencyContext.get()
         dm.add_dependency(KeyCache(), None)
         dm.add_dependency(KeyNoCache(), None)

--- a/test/lib/test_metrics.py
+++ b/test/lib/test_metrics.py
@@ -302,8 +302,6 @@ class TestHwHistogram(TestCaseWithSimulator):
                 await sim.delay(1e-12)  # so verify_process reads correct values
 
         async def verify_process(sim: TestbenchContext):
-            nonlocal min, max, sum, count
-
             for _ in range(iterations):
                 await sim.tick()
 

--- a/transactron/evlog/consumer.py
+++ b/transactron/evlog/consumer.py
@@ -8,15 +8,18 @@ from .log import DecodedEvent
 __all__ = ["handles", "EventConsumer"]
 
 
-def handles(event_type: type[Event]):
+type HandlerMethod[E: Event] = Callable[[Any, DecodedEvent[E]], None]
+
+
+def handles[E: Event](event_type: type[E]) -> Callable[[HandlerMethod[E]], HandlerMethod[E]]:
     """Marks an `EventConsumer` method as the handler for an event type.
 
     The decorated method is called with a single `DecodedEvent` argument for
     every log record of the given event type.
     """
 
-    def wrap(fn):
-        fn._evlog_handles = event_type
+    def wrap(fn: HandlerMethod[E]) -> HandlerMethod[E]:
+        fn._evlog_handles = event_type  # type: ignore
         return fn
 
     return wrap

--- a/transactron/evlog/log.py
+++ b/transactron/evlog/log.py
@@ -23,7 +23,7 @@ type RawEvent = tuple[int, int, list[int]]
 
 
 @dataclass
-class DecodedEvent:
+class DecodedEvent[E: Event = Event]:
     """A single decoded event from an event log.
 
     Attributes
@@ -38,7 +38,7 @@ class DecodedEvent:
 
     cycle: int
     site: EventSiteSchema
-    event: Event
+    event: E
 
     @property
     def source_name(self) -> str:


### PR DESCRIPTION
In Coreblocks `konata` script, there are a lot of type asserts! Evlog was supposed to be typed in principle.

Also, flake8 is updated because it couldn't handle new type syntax.