### PR TITLE
make one_hot_mux ShapeCastable aware

### DIFF
--- a/test/utils/test_amaranth_ext.py
+++ b/test/utils/test_amaranth_ext.py
@@ -3,8 +3,7 @@ import random
 import pytest
 from amaranth import *
 from amaranth.lib.data import ArrayLayout
-from transactron.utils.amaranth_ext import MultiPriorityEncoder, OneHotMux, RingMultiPriorityEncoder
-from transactron.utils.amaranth_ext.functions import one_hot_mux
+from transactron.utils.amaranth_ext import MultiPriorityEncoder, OneHotMux, one_hot_mux, RingMultiPriorityEncoder
 
 
 def get_expected_multi(input_width, output_count, input, *args):

--- a/test/utils/test_amaranth_ext.py
+++ b/test/utils/test_amaranth_ext.py
@@ -69,7 +69,6 @@ class OneHotMuxDUT(Elaboratable):
                     list(zip(self.select, self.inputs)),
                     self.default,
                     priority=self.is_priority,
-                    assert_one_hot=False,
                 )
             )
         else:

--- a/test/utils/test_amaranth_ext.py
+++ b/test/utils/test_amaranth_ext.py
@@ -4,6 +4,7 @@ import pytest
 from amaranth import *
 from amaranth.lib.data import ArrayLayout
 from transactron.utils.amaranth_ext import MultiPriorityEncoder, OneHotMux, RingMultiPriorityEncoder
+from transactron.utils.amaranth_ext.functions import one_hot_mux
 
 
 def get_expected_multi(input_width, output_count, input, *args):
@@ -52,37 +53,57 @@ def one_hot_mux_reference(select_values, input_values, default_value, is_priorit
 
 
 class OneHotMuxDUT(Elaboratable):
-    def __init__(self, shape, input_count, is_priority, has_default):
+    def __init__(self, shape, input_count, is_priority, has_default, use_function):
         self.select = [Signal() for _ in range(input_count)]
         self.inputs = [Signal(shape) for _ in range(input_count)]  # type: ignore
         self.output = Signal(shape)  # type: ignore
         self.default = Signal(shape) if has_default else None  # type: ignore
         self.is_priority = is_priority
+        self.use_function = use_function
 
     def elaborate(self, platform):
         m = Module()
-        m.d.comb += Value.cast(self.output).eq(
-            OneHotMux.create(
-                m,
-                list(zip(self.select, self.inputs)),
-                self.default,
-                priority=self.is_priority,
+        if self.use_function:
+            m.d.comb += self.output.eq(
+                one_hot_mux(
+                    list(zip(self.select, self.inputs)),
+                    self.default,
+                    priority=self.is_priority,
+                    assert_one_hot=False,
+                )
             )
-        )
+        else:
+            m.d.comb += self.output.eq(
+                OneHotMux.create(
+                    m,
+                    list(zip(self.select, self.inputs)),
+                    self.default,
+                    priority=self.is_priority,
+                )
+            )
         return m
 
 
 class TestOneHotMux(TestCaseWithSimulator):
     @pytest.mark.parametrize("is_valuecastable", [False, True])
     @pytest.mark.parametrize("has_default", [False, True])
+    @pytest.mark.parametrize("use_function", [False, True])
     @pytest.mark.parametrize("is_priority", [False, True])
     @pytest.mark.parametrize("input_count", [1, 3, 7])
-    @pytest.mark.parametrize("width", [1, 6, 15])
-    def test_randomized(self, is_valuecastable, has_default, is_priority, input_count, width):
-        random.seed(f"{int(is_valuecastable)}-{int(has_default)}-{int(is_priority)}-{input_count}-{width}")
+    @pytest.mark.parametrize("width", [0, 1, 6, 15])
+    def test_randomized(self, is_valuecastable, has_default, is_priority, input_count, width, use_function):
+        random.seed(
+            f"{int(is_valuecastable)}-{int(has_default)}-{int(is_priority)}-{int(use_function)}-{input_count}-{width}"
+        )
 
         shape = ArrayLayout(1, width) if is_valuecastable else width
-        dut = OneHotMuxDUT(shape=shape, input_count=input_count, is_priority=is_priority, has_default=has_default)
+        dut = OneHotMuxDUT(
+            shape=shape,
+            input_count=input_count,
+            is_priority=is_priority,
+            has_default=has_default,
+            use_function=use_function,
+        )
 
         def from_repr(x):
             return shape.from_bits(x) if is_valuecastable else x

--- a/test/utils/test_amaranth_ext.py
+++ b/test/utils/test_amaranth_ext.py
@@ -116,6 +116,7 @@ class TestOneHotMux(TestCaseWithSimulator):
                 got = sim.get(dut.output)
 
                 if is_valuecastable:
+                    assert got.shape() == shape  # type: ignore
                     got = Const.cast(got).value
 
                 expected = one_hot_mux_reference(

--- a/transactron/core/body.py
+++ b/transactron/core/body.py
@@ -120,7 +120,7 @@ class Body(TransactionBase["Body"]):
     def _default_combiner(shape: ShapeLike):
         def impl(m: Module, args: Sequence[MethodStruct], runs: Value) -> AssignArg:
             arg = Signal(shape)
-            m.d.comb += arg.eq(one_hot_mux([(runs[i], args[i]) for i in range(len(args))], assert_one_hot=False))
+            m.d.comb += arg.eq(one_hot_mux([(runs[i], args[i]) for i in range(len(args))]))
             return arg
 
         return impl

--- a/transactron/core/body.py
+++ b/transactron/core/body.py
@@ -120,7 +120,7 @@ class Body(TransactionBase["Body"]):
     def _default_combiner(shape: ShapeLike):
         def impl(m: Module, args: Sequence[MethodStruct], runs: Value) -> AssignArg:
             arg = Signal(shape)
-            m.d.comb += arg.eq(one_hot_mux(runs, args, assert_one_hot=False))
+            m.d.comb += arg.eq(one_hot_mux([(runs[i], args[i]) for i in range(len(args))], assert_one_hot=False))
             return arg
 
         return impl

--- a/transactron/core/manager.py
+++ b/transactron/core/manager.py
@@ -515,7 +515,7 @@ class TransactionManager(Elaboratable):
                 if method.nonexclusive:
                     return Cat(method._validate_arguments(call.enable, call.arg) for call in calls).all()
 
-                combined = one_hot_mux([(call.enable, call.arg) for call in calls], assert_one_hot=False)
+                combined = one_hot_mux([(call.enable, call.arg) for call in calls])
                 return method._validate_arguments(Cat(call.enable for call in calls).any(), combined)
 
             runnable_terms = [

--- a/transactron/core/manager.py
+++ b/transactron/core/manager.py
@@ -515,7 +515,7 @@ class TransactionManager(Elaboratable):
                 if method.nonexclusive:
                     return Cat(method._validate_arguments(call.enable, call.arg) for call in calls).all()
 
-                combined = OneHotMux.create(m, [(call.enable, call.arg) for call in calls])
+                combined = one_hot_mux([(call.enable, call.arg) for call in calls], assert_one_hot=False)
                 return method._validate_arguments(Cat(call.enable for call in calls).any(), combined)
 
             runnable_terms = [

--- a/transactron/utils/amaranth_ext/elaboratables.py
+++ b/transactron/utils/amaranth_ext/elaboratables.py
@@ -726,8 +726,7 @@ class OneHotMux(Elaboratable):
 
         m.d.comb += Value.cast(self.output).eq(
             one_hot_mux(
-                self.select,
-                [self.inputs[i] for i in range(len(self.select))],
+                [(self.select[i], self.inputs[i]) for i in range(len(self.select))],
                 default=self.default_input if self.has_default else None,
                 priority=self.priority,
                 assert_one_hot=False,

--- a/transactron/utils/amaranth_ext/functions.py
+++ b/transactron/utils/amaranth_ext/functions.py
@@ -385,7 +385,8 @@ def one_hot_mux(
     shape, all_data = _uniformize_values(data if default is None else data + [default])
 
     if len(all_data) == 1:
-        return shape(all_data[0]) if isinstance(shape, ShapeCastable) else all_data[0]
+        value_combined = all_data[0]
+    else:
+        value_combined = or_value([Mux(all_sel[i], all_data[i], C(0, 0)) for i in range(len(all_data))])
 
-    value_combined = or_value([Mux(all_sel[i], all_data[i], C(0, 0)) for i in range(len(all_data))])
     return shape(value_combined) if isinstance(shape, ShapeCastable) else value_combined

--- a/transactron/utils/amaranth_ext/functions.py
+++ b/transactron/utils/amaranth_ext/functions.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, overload
+from typing import Any, Optional, cast, overload
 from amaranth import *
 from amaranth.hdl import ShapeCastable, ValueCastable
 from amaranth.hdl._ast import SwitchValue
@@ -190,7 +190,7 @@ def _uniformize_values(
     shapes = [shape_of(v) for v in values]
     shapecastable_shapes = [shape for shape in shapes if isinstance(shape, ShapeCastable)]
     if not shapecastable_shapes:
-        shapes = [shape for shape in shapes if isinstance(shape, Shape)]
+        shapes = cast(list[Shape], shapes)
         shape_width = max([shape.width for shape in shapes], default=0)
         shape_signed = any(shape.signed for shape in shapes)
         return Shape(shape_width, shape_signed), [Value.cast(v) for v in values]

--- a/transactron/utils/amaranth_ext/functions.py
+++ b/transactron/utils/amaranth_ext/functions.py
@@ -218,11 +218,11 @@ def binary_tree_reduce(*values: ValueBundle, neutral: Value, operator: Callable[
 
 
 def sum_value(*values: ValueBundle):
-    return binary_tree_reduce(*values, neutral=C(0,0), operator=operator.add)
+    return binary_tree_reduce(*values, neutral=C(0, 0), operator=operator.add)
 
 
 def or_value(*values: ValueBundle):
-    return binary_tree_reduce(*values, neutral=C(0,0), operator=operator.or_)
+    return binary_tree_reduce(*values, neutral=C(0, 0), operator=operator.or_)
 
 
 def and_value(*values: ValueBundle):
@@ -390,7 +390,7 @@ def one_hot_mux(
     if len(all_data) == 1:
         return shape(all_data[0]) if isinstance(shape, ShapeCastable) else all_data[0]
 
-    value_combined = or_value([Mux(all_sel[i], all_data[i], C(0,0)) for i in range(len(all_data))])
+    value_combined = or_value([Mux(all_sel[i], all_data[i], C(0, 0)) for i in range(len(all_data))])
 
     if isinstance(shape, ShapeCastable):
         value_combined = value_combined[: Shape.cast(shape).width]

--- a/transactron/utils/amaranth_ext/functions.py
+++ b/transactron/utils/amaranth_ext/functions.py
@@ -388,9 +388,4 @@ def one_hot_mux(
         return shape(all_data[0]) if isinstance(shape, ShapeCastable) else all_data[0]
 
     value_combined = or_value([Mux(all_sel[i], all_data[i], C(0, 0)) for i in range(len(all_data))])
-
-    if isinstance(shape, ShapeCastable):
-        value_combined = value_combined[: Shape.cast(shape).width]
-        return shape(value_combined)
-
-    return value_combined
+    return shape(value_combined) if isinstance(shape, ShapeCastable) else value_combined

--- a/transactron/utils/amaranth_ext/functions.py
+++ b/transactron/utils/amaranth_ext/functions.py
@@ -168,29 +168,29 @@ def const_of(value: int, shape: ShapeLike) -> Any:
 @overload
 def _uniformize_values(
     values: Iterable[FlatValueLike],
-) -> tuple[None, list[Value]]: ...
+) -> tuple[Callable[[Value], Value], list[Value]]: ...
 
 
 @overload
 def _uniformize_values[
     T: ValueCastable
-](values: Iterable[T],) -> tuple[ShapeCastable, list[Value]]: ...
+](values: Iterable[T],) -> tuple[Callable[[Value], T], list[Value]]: ...
 
 
 @overload
 def _uniformize_values(
     values: Iterable[ValueLike],
-) -> tuple[ShapeCastable | None, list[Value]]: ...
+) -> tuple[Callable[[Value], Value | ValueCastable], list[Value]]: ...
 
 
 def _uniformize_values(
     values: Iterable[ValueLike],
-) -> tuple[ShapeCastable | None, list[Value]]:
+) -> tuple[Callable[[Value], Value | ValueCastable], list[Value]]:
     values = list(values)
     shapes = [shape_of(v) for v in values]
     shapecastable_shapes = [shape for shape in shapes if isinstance(shape, ShapeCastable)]
     if not shapecastable_shapes:
-        return None, [Value.cast(v) for v in values]
+        return (lambda v: v), [Value.cast(v) for v in values]
 
     shape = shapecastable_shapes[0]
     if any(case_shape != shape for case_shape in shapecastable_shapes):
@@ -199,7 +199,7 @@ def _uniformize_values(
     def unify(v):
         return Value.cast(v) if isinstance(v, (Value, ValueCastable)) else Value.cast(shape.const(v))
 
-    return shape, [unify(v) for v in values]
+    return (lambda v: shape(v)), [unify(v) for v in values]
 
 
 def binary_tree_reduce(*values: ValueBundle, neutral: Value, operator: Callable[[Value, Value], Value]) -> Value:
@@ -275,9 +275,9 @@ def switch_value(
 ) -> ValueLike:
     src_loc = get_src_loc(src_loc)
     cases = list(cases)
-    shape, values = _uniformize_values(val for _, val in cases)
+    shape_cast, values = _uniformize_values(val for _, val in cases)
     ret_val = SwitchValue(test, [(key, val) for (key, _), val in zip(cases, values)], src_loc=src_loc)
-    return shape(ret_val) if isinstance(shape, ShapeCastable) else ret_val
+    return shape_cast(ret_val)
 
 
 @overload
@@ -382,11 +382,9 @@ def one_hot_mux(
         )
 
     all_sel = select_one_hot if default is None else Cat(select_one_hot, ~select.any())
-    shape, all_data = _uniformize_values(data if default is None else data + [default])
+    shape_cast, all_data = _uniformize_values(data if default is None else data + [default])
 
     if len(all_data) == 1:
-        value_combined = all_data[0]
-    else:
-        value_combined = or_value([Mux(all_sel[i], all_data[i], C(0, 0)) for i in range(len(all_data))])
+        return shape_cast(all_data[0])
 
-    return shape(value_combined) if isinstance(shape, ShapeCastable) else value_combined
+    return shape_cast(or_value([Mux(all_sel[i], all_data[i], C(0, 0)) for i in range(len(all_data))]))

--- a/transactron/utils/amaranth_ext/functions.py
+++ b/transactron/utils/amaranth_ext/functions.py
@@ -218,11 +218,11 @@ def binary_tree_reduce(*values: ValueBundle, neutral: Value, operator: Callable[
 
 
 def sum_value(*values: ValueBundle):
-    return binary_tree_reduce(*values, neutral=C(0), operator=operator.add)
+    return binary_tree_reduce(*values, neutral=C(0,0), operator=operator.add)
 
 
 def or_value(*values: ValueBundle):
-    return binary_tree_reduce(*values, neutral=C(0), operator=operator.or_)
+    return binary_tree_reduce(*values, neutral=C(0,0), operator=operator.or_)
 
 
 def and_value(*values: ValueBundle):
@@ -279,9 +279,6 @@ def switch_value(
     src_loc = get_src_loc(src_loc)
     cases = list(cases)
     shape, values = _uniformize_values(val for _, val in cases)
-    if Shape.cast(shape).width == 0:
-        return shape.from_bits(0) if isinstance(shape, ShapeCastable) else C(0)
-
     ret_val = SwitchValue(test, [(key, val) for (key, _), val in zip(cases, values)], src_loc=src_loc)
     return shape(ret_val) if isinstance(shape, ShapeCastable) else ret_val
 
@@ -390,14 +387,10 @@ def one_hot_mux(
     all_sel = select_one_hot if default is None else Cat(select_one_hot, ~select.any())
     shape, all_data = _uniformize_values(data if default is None else data + [default])
 
-    if Shape.cast(shape).width == 0:
-        # Mux of 0-wide value is 1-wide - just return a shape-casted 0
-        return shape.from_bits(0) if isinstance(shape, ShapeCastable) else C(0)
-
     if len(all_data) == 1:
         return shape(all_data[0]) if isinstance(shape, ShapeCastable) else all_data[0]
 
-    value_combined = or_value([Mux(all_sel[i], all_data[i], 0) for i in range(len(all_data))])
+    value_combined = or_value([Mux(all_sel[i], all_data[i], C(0,0)) for i in range(len(all_data))])
 
     if isinstance(shape, ShapeCastable):
         value_combined = value_combined[: Shape.cast(shape).width]

--- a/transactron/utils/amaranth_ext/functions.py
+++ b/transactron/utils/amaranth_ext/functions.py
@@ -337,7 +337,7 @@ def one_hot_mux(
     inputs: Sequence[tuple[ValueLike, ValueLike]],
     default: Optional[ValueLike] = None,
     priority: bool = False,
-    assert_one_hot: bool = True,
+    assert_one_hot: bool = False,
 ) -> Value | ValueCastable:
     """
     One-hot multiplexer.
@@ -353,7 +353,7 @@ def one_hot_mux(
     priority : bool, default False
         If True, the output corresponds to the lowest entry with set select signal.
         If False, the output is undefined if multiple select signals are set.
-    assert_one_hot : bool, default True
+    assert_one_hot : bool, default False
         If True, an assertion is added that checks if undefined output is produced.
     """
     inputs = list(inputs)

--- a/transactron/utils/amaranth_ext/functions.py
+++ b/transactron/utils/amaranth_ext/functions.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, cast, overload
+from typing import Any, Optional, overload
 from amaranth import *
 from amaranth.hdl import ShapeCastable, ValueCastable
 from amaranth.hdl._ast import SwitchValue
@@ -165,6 +165,46 @@ def const_of(value: int, shape: ShapeLike) -> Any:
         return C(value, Shape.cast(shape))
 
 
+@overload
+def _uniformize_values(
+    values: Iterable[FlatValueLike],
+) -> tuple[Shape, list[Value]]: ...
+
+
+@overload
+def _uniformize_values[
+    T: ValueCastable
+](values: Iterable[T],) -> tuple[ShapeCastable, list[Value]]: ...
+
+
+@overload
+def _uniformize_values(
+    values: Iterable[ValueLike],
+) -> tuple[ShapeCastable | Shape, list[Value]]: ...
+
+
+def _uniformize_values(
+    values: Iterable[ValueLike],
+) -> tuple[ShapeCastable | Shape, list[Value]]:
+    values = list(values)
+    shapes = [shape_of(v) for v in values]
+    shapecastable_shapes = [shape for shape in shapes if isinstance(shape, ShapeCastable)]
+    if not shapecastable_shapes:
+        shapes = [shape for shape in shapes if isinstance(shape, Shape)]
+        shape_width = max([shape.width for shape in shapes], default=0)
+        shape_signed = any(shape.signed for shape in shapes)
+        return Shape(shape_width, shape_signed), [Value.cast(v) for v in values]
+
+    shape = shapecastable_shapes[0]
+    if any(case_shape != shape for case_shape in shapecastable_shapes):
+        raise ValueError("Different ShapeCastables for different shapes")
+
+    def unify(v):
+        return Value.cast(v) if isinstance(v, (Value, ValueCastable)) else Value.cast(shape.const(v))
+
+    return shape, [unify(v) for v in values]
+
+
 def binary_tree_reduce(*values: ValueBundle, neutral: Value, operator: Callable[[Value, Value], Value]) -> Value:
     min_layers = list(flatten_signals(values))
     if not min_layers:
@@ -238,19 +278,12 @@ def switch_value(
 ) -> ValueLike:
     src_loc = get_src_loc(src_loc)
     cases = list(cases)
-    case_shapes = [shape_of(val) for _, val in cases]
-    shapecastable_shapes = [shape for shape in case_shapes if isinstance(shape, ShapeCastable)]
-    if shapecastable_shapes:
-        shape = cast(ShapeCastable, shapecastable_shapes[0])
-        if any(case_shape != shape for case_shape in shapecastable_shapes):
-            raise ValueError("Different ShapeCastables for different shapes")
+    shape, values = _uniformize_values(val for _, val in cases)
+    if Shape.cast(shape).width == 0:
+        return shape.from_bits(0) if isinstance(shape, ShapeCastable) else C(0)
 
-        def unify(v):
-            return Value.cast(v) if isinstance(v, (Value, ValueCastable)) else Value.cast(shape.const(v))
-
-        return shape(SwitchValue(test, [(key, unify(val)) for key, val in cases], src_loc=src_loc))
-    else:
-        return SwitchValue(test, cases, src_loc=src_loc)
+    ret_val = SwitchValue(test, [(key, val) for (key, _), val in zip(cases, values)], src_loc=src_loc)
+    return shape(ret_val) if isinstance(shape, ShapeCastable) else ret_val
 
 
 @overload
@@ -277,13 +310,45 @@ def mux(sel: ValueLike, val1: ValueLike, val0: ValueLike) -> ValueLike:
     return switch_value(sel, [(0, val0), (None, val1)], src_loc=1)
 
 
+@overload
+def one_hot_mux[
+    T: ValueCastable
+](
+    select: ValueLike,
+    inputs: Sequence[T],
+    default: Optional[T] = None,
+    priority: bool = False,
+    assert_one_hot: bool = True,
+) -> T: ...
+
+
+@overload
+def one_hot_mux(
+    select: ValueLike,
+    inputs: Sequence[FlatValueLike],
+    default: Optional[FlatValueLike] = None,
+    priority: bool = False,
+    assert_one_hot: bool = True,
+) -> Value: ...
+
+
+@overload
 def one_hot_mux(
     select: ValueLike,
     inputs: Sequence[ValueLike],
     default: Optional[ValueLike] = None,
     priority: bool = False,
     assert_one_hot: bool = True,
-) -> Value:
+) -> Value | ValueCastable: ...
+
+
+def one_hot_mux(
+    select: ValueLike,
+    inputs: Sequence[ValueLike],
+    default: Optional[ValueLike] = None,
+    priority: bool = False,
+    assert_one_hot: bool = True,
+) -> Value | ValueCastable:
     """
     One-hot multiplexer.
     Takes n input values and a one-hot select signal of n bits and outputs the value corresponding
@@ -296,11 +361,10 @@ def one_hot_mux(
     otherwise select must have at least one bit set.
     """
     inputs = list(inputs)
+    select = Value.cast(select)
 
-    if len(inputs) == 0:
-        return Value.cast(default) if default is not None else C(0)
-
-    select = Value.cast(select).as_unsigned()
+    if not inputs and default is None:
+        raise ValueError("No inputs provided to one_hot_mux")
 
     if default is None and assert_one_hot:
         top_assertion(
@@ -309,10 +373,7 @@ def one_hot_mux(
             src_loc=1,
         )
 
-    if default is None and len(inputs) == 1:
-        return Value.cast(inputs[0])
-
-    select_first = select & (~select + 1)
+    select_first = (select & (~select + 1))[: len(inputs)]
     select_one_hot = select_first if priority else select
 
     if not priority and assert_one_hot:
@@ -323,9 +384,21 @@ def one_hot_mux(
             src_loc=1,
         )
 
-    value_combined = or_value([Mux(select_one_hot[i], Value.cast(inputs[i]), 0) for i in range(len(inputs))])
+    all_inputs = inputs if default is None else inputs + [default]
+    shape, all_inputs = _uniformize_values(all_inputs)
 
-    if default is None:
-        return value_combined
+    if len(all_inputs) == 1:
+        return all_inputs[0]
 
-    return Mux(select.any(), value_combined, Value.cast(default))
+    if Shape.cast(shape).width == 0:
+        # Mux of 0-wide value is 1-wide - just return a shape-casted 0
+        return shape.from_bits(0) if isinstance(shape, ShapeCastable) else C(0)
+
+    all_select = select_one_hot if default is None else Cat(select_one_hot, ~select.any())
+    value_combined = or_value([Mux(all_select[i], all_inputs[i], 0) for i in range(len(all_inputs))])
+
+    if isinstance(shape, ShapeCastable):
+        value_combined = value_combined[: Shape.cast(shape).width]
+        return shape(value_combined)
+
+    return value_combined

--- a/transactron/utils/amaranth_ext/functions.py
+++ b/transactron/utils/amaranth_ext/functions.py
@@ -314,8 +314,7 @@ def mux(sel: ValueLike, val1: ValueLike, val0: ValueLike) -> ValueLike:
 def one_hot_mux[
     T: ValueCastable
 ](
-    select: ValueLike,
-    inputs: Sequence[T],
+    inputs: Sequence[tuple[ValueLike, T]],
     default: Optional[T] = None,
     priority: bool = False,
     assert_one_hot: bool = True,
@@ -324,8 +323,7 @@ def one_hot_mux[
 
 @overload
 def one_hot_mux(
-    select: ValueLike,
-    inputs: Sequence[FlatValueLike],
+    inputs: Sequence[tuple[ValueLike, FlatValueLike]],
     default: Optional[FlatValueLike] = None,
     priority: bool = False,
     assert_one_hot: bool = True,
@@ -334,8 +332,7 @@ def one_hot_mux(
 
 @overload
 def one_hot_mux(
-    select: ValueLike,
-    inputs: Sequence[ValueLike],
+    inputs: Sequence[tuple[ValueLike, ValueLike]],
     default: Optional[ValueLike] = None,
     priority: bool = False,
     assert_one_hot: bool = True,
@@ -343,25 +340,31 @@ def one_hot_mux(
 
 
 def one_hot_mux(
-    select: ValueLike,
-    inputs: Sequence[ValueLike],
+    inputs: Sequence[tuple[ValueLike, ValueLike]],
     default: Optional[ValueLike] = None,
     priority: bool = False,
     assert_one_hot: bool = True,
 ) -> Value | ValueCastable:
     """
     One-hot multiplexer.
-    Takes n input values and a one-hot select signal of n bits and outputs the value corresponding
-    to the bit set in the select signal.
-    If priority is False and multiple bits are set, the output is undefined.
-    If priority is True and multiple bits are set, the output corresponds to the lowest set bit in the select signal.
-    If assert_one_hot is True and priority is False, an assertion is added that checks
-    that the select signal is one-hot.
-    If default is provided and select signal is 0, the output is default,
-    otherwise select must have at least one bit set.
+    Takes n input values and n one-hot select signals and outputs the value corresponding to the set select signal.
+
+    Parameters
+    ----------
+    inputs : Sequence[tuple[ValueLike, ValueLike]]
+        Sequence of tuples, where each tuple contains a select signal and a corresponding value.
+    default: ValueLike, optional
+        Default value to output if no select signal is set. If not provided, when no select signal is set, the output
+        is undefined.
+    priority : bool, default False
+        If True, the output corresponds to the lowest entry with set select signal.
+        If False, the output is undefined if multiple select signals are set.
+    assert_one_hot : bool, default True
+        If True, an assertion is added that checks if undefined output is produced.
     """
     inputs = list(inputs)
-    select = Value.cast(select)
+    select = Cat(Value.cast(sel).bool() for sel, _ in inputs)
+    data = [val for _, val in inputs]
 
     if not inputs and default is None:
         raise ValueError("No inputs provided to one_hot_mux")
@@ -384,18 +387,17 @@ def one_hot_mux(
             src_loc=1,
         )
 
-    all_inputs = inputs if default is None else inputs + [default]
-    shape, all_inputs = _uniformize_values(all_inputs)
-
-    if len(all_inputs) == 1:
-        return all_inputs[0]
+    all_sel = select_one_hot if default is None else Cat(select_one_hot, ~select.any())
+    shape, all_data = _uniformize_values(data if default is None else data + [default])
 
     if Shape.cast(shape).width == 0:
         # Mux of 0-wide value is 1-wide - just return a shape-casted 0
         return shape.from_bits(0) if isinstance(shape, ShapeCastable) else C(0)
 
-    all_select = select_one_hot if default is None else Cat(select_one_hot, ~select.any())
-    value_combined = or_value([Mux(all_select[i], all_inputs[i], 0) for i in range(len(all_inputs))])
+    if len(all_data) == 1:
+        return shape(all_data[0]) if isinstance(shape, ShapeCastable) else all_data[0]
+
+    value_combined = or_value([Mux(all_sel[i], all_data[i], 0) for i in range(len(all_data))])
 
     if isinstance(shape, ShapeCastable):
         value_combined = value_combined[: Shape.cast(shape).width]

--- a/transactron/utils/amaranth_ext/functions.py
+++ b/transactron/utils/amaranth_ext/functions.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, cast, overload
+from typing import Any, Optional, overload
 from amaranth import *
 from amaranth.hdl import ShapeCastable, ValueCastable
 from amaranth.hdl._ast import SwitchValue
@@ -168,7 +168,7 @@ def const_of(value: int, shape: ShapeLike) -> Any:
 @overload
 def _uniformize_values(
     values: Iterable[FlatValueLike],
-) -> tuple[Shape, list[Value]]: ...
+) -> tuple[None, list[Value]]: ...
 
 
 @overload
@@ -180,20 +180,17 @@ def _uniformize_values[
 @overload
 def _uniformize_values(
     values: Iterable[ValueLike],
-) -> tuple[ShapeCastable | Shape, list[Value]]: ...
+) -> tuple[ShapeCastable | None, list[Value]]: ...
 
 
 def _uniformize_values(
     values: Iterable[ValueLike],
-) -> tuple[ShapeCastable | Shape, list[Value]]:
+) -> tuple[ShapeCastable | None, list[Value]]:
     values = list(values)
     shapes = [shape_of(v) for v in values]
     shapecastable_shapes = [shape for shape in shapes if isinstance(shape, ShapeCastable)]
     if not shapecastable_shapes:
-        shapes = cast(list[Shape], shapes)
-        shape_width = max([shape.width for shape in shapes], default=0)
-        shape_signed = any(shape.signed for shape in shapes)
-        return Shape(shape_width, shape_signed), [Value.cast(v) for v in values]
+        return None, [Value.cast(v) for v in values]
 
     shape = shapecastable_shapes[0]
     if any(case_shape != shape for case_shape in shapecastable_shapes):


### PR DESCRIPTION
Makes `one_hot_mux` shape aware - line `mux` and `switch_value`.
~Also fixes the bug with `mux` and `switch_value` where they failed on 0-wide `ValueCastable`s - `SwitchValue` returns 1-wide value when all it's arguments are 0-wide.~

Related to #219.

Transactron uses internally `one_hot_mux` for method argument combiners, thus testing it quite well on many different shape castables.