### PR TITLE
Introduce bitmagic helper functions

### DIFF
--- a/test/utils/test_utils.py
+++ b/test/utils/test_utils.py
@@ -11,6 +11,12 @@ from transactron.utils import (
     count_leading_zeros,
     count_trailing_zeros,
     cyclic_mask,
+    extract_lowest_set_bit,
+    clear_lowest_set_bit,
+    mask_after_first_set_bit,
+    mask_from_first_set_bit,
+    mask_until_first_set_bit,
+    mask_before_first_set_bit,
 )
 from amaranth.utils import ceil_log2
 
@@ -245,3 +251,75 @@ class TestGenCyclicMask(TestCaseWithSimulator):
     def test_count_trailing_zeros(self, size):
         with self.run_simulation(self.m) as sim:
             sim.add_testbench(self.process)
+
+
+def reference_extract_lowest_set_bit(n, width):
+    if n == 0:
+        return 0
+    ctz = bin(n)[::-1].find("1")
+    return 1 << ctz
+
+
+def reference_clear_lowest_set_bit(n, width):
+    return n & ~reference_extract_lowest_set_bit(n, width)
+
+
+def reference_mask_after_first_set_bit(n, width):
+    if n == 0:
+        return 0
+    ctz = bin(n)[::-1].find("1")
+    return (-1 << (ctz + 1)) & ((1 << width) - 1)
+
+
+def reference_mask_from_first_set_bit(n, width):
+    if n == 0:
+        return 0
+    ctz = bin(n)[::-1].find("1")
+    return (-1 << ctz) & ((1 << width) - 1)
+
+
+def reference_mask_until_first_set_bit(n, width):
+    if n == 0:
+        return (1 << width) - 1
+    ctz = bin(n)[::-1].find("1")
+    return (1 << (ctz+1)) - 1
+
+
+def reference_mask_before_first_set_bit(n, width):
+    if n == 0:
+        return (1 << width) - 1
+    ctz = bin(n)[::-1].find("1")
+    return (1 << ctz) - 1
+
+
+class TestBitManipulationFunctions(TestCaseWithSimulator):
+    def do_test(self, function, ref_function):
+        async def process(sim: TestbenchContext):
+            for _ in range(40):
+                width = random.randint(0, 32)
+                value = random.randint(0, (1 << width) - 1)
+                result = sim.get(function(Const(value, width)))
+                expected = ref_function(value, width)
+                assert result == expected, f"Failed for value {value} with width {width}"
+
+        with self.run_simulation(Module()) as sim:
+            sim.add_testbench(process)
+
+    def test_extract_lowest_set_bit(self):
+        self.do_test(extract_lowest_set_bit, reference_extract_lowest_set_bit)
+
+    def test_clear_lowest_set_bit(self):
+        self.do_test(clear_lowest_set_bit, reference_clear_lowest_set_bit)
+
+    def test_mask_after_first_set_bit(self):
+        self.do_test(mask_after_first_set_bit, reference_mask_after_first_set_bit)
+
+    def test_mask_from_first_set_bit(self):
+        self.do_test(mask_from_first_set_bit, reference_mask_from_first_set_bit)
+
+    def test_mask_until_first_set_bit(self):
+        self.do_test(mask_until_first_set_bit, reference_mask_until_first_set_bit)
+
+    def test_mask_before_first_set_bit(self):
+        self.do_test(mask_before_first_set_bit, reference_mask_before_first_set_bit)
+

--- a/test/utils/test_utils.py
+++ b/test/utils/test_utils.py
@@ -282,7 +282,7 @@ def reference_mask_until_first_set_bit(n, width):
     if n == 0:
         return (1 << width) - 1
     ctz = bin(n)[::-1].find("1")
-    return (1 << (ctz+1)) - 1
+    return (1 << (ctz + 1)) - 1
 
 
 def reference_mask_before_first_set_bit(n, width):
@@ -322,4 +322,3 @@ class TestBitManipulationFunctions(TestCaseWithSimulator):
 
     def test_mask_before_first_set_bit(self):
         self.do_test(mask_before_first_set_bit, reference_mask_before_first_set_bit)
-

--- a/transactron/utils/amaranth_ext/functions.py
+++ b/transactron/utils/amaranth_ext/functions.py
@@ -377,7 +377,7 @@ def one_hot_mux(
             src_loc=1,
         )
 
-    select_first = (select & (~select + 1))[: len(inputs)]
+    select_first = extract_lowest_set_bit(select)
     select_one_hot = select_first if priority else select
 
     if not priority and assert_one_hot:

--- a/transactron/utils/amaranth_ext/functions.py
+++ b/transactron/utils/amaranth_ext/functions.py
@@ -33,6 +33,13 @@ __all__ = [
     "switch_value",
     "mux",
     "one_hot_mux",
+    "extract_lowest_set_bit",
+    "extract_highest_set_bit",
+    "clear_lowest_set_bit",
+    "mask_from_first_set_bit",
+    "mask_after_first_set_bit",
+    "mask_until_first_set_bit",
+    "mask_before_first_set_bit",
 ]
 
 
@@ -388,3 +395,65 @@ def one_hot_mux(
         return shape_cast(all_data[0])
 
     return shape_cast(or_value([Mux(all_sel[i], all_data[i], C(0, 0)) for i in range(len(all_data))]))
+
+
+def extract_lowest_set_bit(value: Value) -> Value:
+    """
+    Extracts the lowest set bit from the input value.
+    If no bits are set, returns 0.
+    For example 0b010100 -> 0b000100.
+    Same as: (1 << count_trailing_zeros(value))[: len(value)].
+    """
+    return (value & -value)[: len(value)]
+
+
+def extract_highest_set_bit(value: Value) -> Value:
+    """
+    Extracts the highest set bit from the input value.
+    If no bits are set, returns 0.
+    For example 0b010100 -> 0b010000.
+    """
+    return extract_lowest_set_bit(value[::-1])[::-1]
+
+
+def clear_lowest_set_bit(value: Value) -> Value:
+    """
+    Clears the lowest set bit from the input value.
+    If no bits are set, returns 0.
+    For example 0b110100 -> 0b110000.
+    """
+    return (value & (value - 1))[: len(value)]
+
+
+def mask_from_first_set_bit(value: Value) -> Value:
+    """
+    Generates a mask from the first set bit (inclusive) in the input value upto its length.
+    For example 0b010100 -> 0b111100.
+    Same as: (-1 << count_trailing_zeros(value))[: len(value)].
+    """
+    return (value | -value)[: len(value)]
+
+
+def mask_after_first_set_bit(value: Value) -> Value:
+    """
+    Generates a mask from the first set bit (exclusive) in the input value upto its length.
+    For example 0b010100 -> 0b111000.
+    """
+    return (mask_from_first_set_bit(value) << 1)[: len(value)]
+
+
+def mask_until_first_set_bit(value: Value) -> Value:
+    """
+    Generates a mask from the 0-th bit upto the first set bit in the input (inclusive).
+    For example 0b010100 -> 0b000111.
+    """
+    return ~mask_after_first_set_bit(value)
+
+
+def mask_before_first_set_bit(value: Value) -> Value:
+    """
+    Generates a mask from the 0-th bit upto the first set bit in the input (exclusive).
+    For example 0b010100 -> 0b000011.
+    Same as: extract_lowest_set_bit(value) - 1.
+    """
+    return ~mask_from_first_set_bit(value)

--- a/transactron/utils/amaranth_ext/functions.py
+++ b/transactron/utils/amaranth_ext/functions.py
@@ -398,7 +398,7 @@ def one_hot_mux(
 
 def extract_lowest_set_bit(value: Value) -> Value:
     """
-    Extracts the lowest set bit from the input value.
+    Extracts the least significant set bit from the input value.
     If no bits are set, returns 0.
     For example 0b010100 -> 0b000100.
     Same as: (1 << count_trailing_zeros(value))[: len(value)].
@@ -408,7 +408,7 @@ def extract_lowest_set_bit(value: Value) -> Value:
 
 def clear_lowest_set_bit(value: Value) -> Value:
     """
-    Clears the lowest set bit from the input value.
+    Clears the least significant set bit from the input value.
     If no bits are set, returns 0.
     For example 0b110100 -> 0b110000.
     Same as: value & ~extract_lowest_set_bit(value)
@@ -418,7 +418,7 @@ def clear_lowest_set_bit(value: Value) -> Value:
 
 def mask_from_first_set_bit(value: Value) -> Value:
     """
-    Generates a mask from the first set bit (inclusive) in the input value upto its length.
+    Generates a mask from the least significant set bit (inclusive) in the input value upto its length.
     For example 0b010100 -> 0b111100.
     Same as: (-1 << count_trailing_zeros(value))[: len(value)].
     """
@@ -427,7 +427,7 @@ def mask_from_first_set_bit(value: Value) -> Value:
 
 def mask_after_first_set_bit(value: Value) -> Value:
     """
-    Generates a mask from the first set bit (exclusive) in the input value upto its length.
+    Generates a mask from the least significant set bit (exclusive) in the input value upto its length.
     For example 0b010100 -> 0b111000.
     """
     return (mask_from_first_set_bit(value) << 1)[: len(value)]
@@ -435,7 +435,7 @@ def mask_after_first_set_bit(value: Value) -> Value:
 
 def mask_until_first_set_bit(value: Value) -> Value:
     """
-    Generates a mask from the 0-th bit upto the first set bit in the input (inclusive).
+    Generates a mask from the 0-th bit upto the least significant set bit in the input (inclusive).
     For example 0b010100 -> 0b000111.
     """
     return ~mask_after_first_set_bit(value)
@@ -443,7 +443,7 @@ def mask_until_first_set_bit(value: Value) -> Value:
 
 def mask_before_first_set_bit(value: Value) -> Value:
     """
-    Generates a mask from the 0-th bit upto the first set bit in the input (exclusive).
+    Generates a mask from the 0-th bit upto the least significant set bit in the input (exclusive).
     For example 0b010100 -> 0b000011.
     Same as: extract_lowest_set_bit(value) - 1.
     """

--- a/transactron/utils/amaranth_ext/functions.py
+++ b/transactron/utils/amaranth_ext/functions.py
@@ -399,9 +399,9 @@ def one_hot_mux(
 def extract_lowest_set_bit(value: Value) -> Value:
     """
     Extracts the least significant set bit from the input value.
-    If no bits are set, returns 0.
-    For example 0b010100 -> 0b000100.
-    Same as: (1 << count_trailing_zeros(value))[: len(value)].
+    If no bits are set, returns ``0``.
+    For example ``0b010100`` -> ``0b000100``.
+    Same as: ``(1 << count_trailing_zeros(value))[: len(value)]``.
     """
     return (value & -value)[: len(value)]
 
@@ -409,9 +409,9 @@ def extract_lowest_set_bit(value: Value) -> Value:
 def clear_lowest_set_bit(value: Value) -> Value:
     """
     Clears the least significant set bit from the input value.
-    If no bits are set, returns 0.
-    For example 0b110100 -> 0b110000.
-    Same as: value & ~extract_lowest_set_bit(value)
+    If no bits are set, returns ``0``.
+    For example ``0b110100`` -> ``0b110000``.
+    Same as: ``value & ~extract_lowest_set_bit(value)``
     """
     return (value & (value - 1))[: len(value)]
 
@@ -419,8 +419,8 @@ def clear_lowest_set_bit(value: Value) -> Value:
 def mask_from_first_set_bit(value: Value) -> Value:
     """
     Generates a mask from the least significant set bit (inclusive) in the input value upto its length.
-    For example 0b010100 -> 0b111100.
-    Same as: (-1 << count_trailing_zeros(value))[: len(value)].
+    For example ``0b010100`` -> ``0b111100``.
+    Same as: ``(-1 << count_trailing_zeros(value))[: len(value)]``.
     """
     return (value | -value)[: len(value)]
 
@@ -428,7 +428,7 @@ def mask_from_first_set_bit(value: Value) -> Value:
 def mask_after_first_set_bit(value: Value) -> Value:
     """
     Generates a mask from the least significant set bit (exclusive) in the input value upto its length.
-    For example 0b010100 -> 0b111000.
+    For example ``0b010100`` -> ``0b111000``.
     """
     return (mask_from_first_set_bit(value) << 1)[: len(value)]
 
@@ -436,7 +436,7 @@ def mask_after_first_set_bit(value: Value) -> Value:
 def mask_until_first_set_bit(value: Value) -> Value:
     """
     Generates a mask from the 0-th bit upto the least significant set bit in the input (inclusive).
-    For example 0b010100 -> 0b000111.
+    For example ``0b010100`` -> ``0b000111``.
     """
     return ~mask_after_first_set_bit(value)
 
@@ -444,7 +444,7 @@ def mask_until_first_set_bit(value: Value) -> Value:
 def mask_before_first_set_bit(value: Value) -> Value:
     """
     Generates a mask from the 0-th bit upto the least significant set bit in the input (exclusive).
-    For example 0b010100 -> 0b000011.
-    Same as: extract_lowest_set_bit(value) - 1.
+    For example ``0b010100`` -> ``0b000011``.
+    Same as: ``extract_lowest_set_bit(value) - 1``.
     """
     return ~mask_from_first_set_bit(value)

--- a/transactron/utils/amaranth_ext/functions.py
+++ b/transactron/utils/amaranth_ext/functions.py
@@ -34,7 +34,6 @@ __all__ = [
     "mux",
     "one_hot_mux",
     "extract_lowest_set_bit",
-    "extract_highest_set_bit",
     "clear_lowest_set_bit",
     "mask_from_first_set_bit",
     "mask_after_first_set_bit",
@@ -407,20 +406,12 @@ def extract_lowest_set_bit(value: Value) -> Value:
     return (value & -value)[: len(value)]
 
 
-def extract_highest_set_bit(value: Value) -> Value:
-    """
-    Extracts the highest set bit from the input value.
-    If no bits are set, returns 0.
-    For example 0b010100 -> 0b010000.
-    """
-    return extract_lowest_set_bit(value[::-1])[::-1]
-
-
 def clear_lowest_set_bit(value: Value) -> Value:
     """
     Clears the lowest set bit from the input value.
     If no bits are set, returns 0.
     For example 0b110100 -> 0b110000.
+    Same as: value & ~extract_lowest_set_bit(value)
     """
     return (value & (value - 1))[: len(value)]
 


### PR DESCRIPTION
Closes #222 

Introduce helpers for common bit manipulation tricks to increase readability.

We need to be consistent about naming the naming of those instruction.
For now I treat the values as bit-vectors with LSB at the front (like indexing in amaranth treats them). This may introduce some confusion, as `count_{leading,trailing}_zeros` treat them as bit-vectors with MSB at the front (as how numbers are written down).