### PR TITLE
Make hypothesis even better

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
           pip3 install --group test .[testing]
 
       - name: Run tests
-        run: COVERAGE_CORE=sysmon pytest --verbose -n auto --transactron-traces --transactron-profile --durations 0 --cov transactron
+        run: COVERAGE_CORE=sysmon pytest --verbose -n auto --transactron-traces --transactron-profile --durations 0 --cov transactron --hypothesis-profile=ci
 
       - name: Write coverage report to summary
         run: coverage report --format=markdown >> $GITHUB_STEP_SUMMARY

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,5 +1,14 @@
 import os
 import pytest
+import hypothesis
+
+
+hypothesis.settings.register_profile(
+    "ci",
+    derandomize=True,  # reproducible runs in CI
+    max_examples=100,  # don't do too much tests
+    deadline=None,  # avoid flakiness due to runner variability
+)
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:

--- a/test/lib/test_stack.py
+++ b/test/lib/test_stack.py
@@ -1,27 +1,31 @@
 import pytest
-import random
 from transactron.lib.stack import Stack
 from transactron.testing import TestCaseWithSimulator, data_layout, TestbenchContext, SimpleTestCircuit
+from transactron.testing.input_generation import draw_wait_geom
+from hypothesis import given, settings
+import hypothesis.strategies as st
 
 
 class TestStack(TestCaseWithSimulator):
     @pytest.mark.parametrize("depth", [5, 4])
-    def test_randomized(self, depth):
+    @settings(max_examples=10, deadline=1000)
+    @given(st.data())
+    def test_randomized(self, depth, data: st.DataObject):
         width = 8
         layout = data_layout(width)
         circ = SimpleTestCircuit(Stack(layout=layout, depth=depth))
         stk: list[int] = []
 
-        cycles = 256
-        random.seed(42)
+        cycles = 100
 
         self.done = False
 
         async def source(sim: TestbenchContext):
             for _ in range(cycles):
-                await self.random_wait_geom(sim, 0.5)
+                await draw_wait_geom(sim, data, 0.5)
 
-                v = random.randrange(0, 2**width)
+                v = data.draw(st.integers(0, 2**width-1))
+                #print(v)
                 await circ.write.call(sim, data=v)
                 await sim.delay(2e-9)
                 stk.append(v)
@@ -30,7 +34,7 @@ class TestStack(TestCaseWithSimulator):
 
         async def target(sim: TestbenchContext):
             while not self.done or stk:
-                await self.random_wait_geom(sim, 0.5)
+                await draw_wait_geom(sim, data, 0.5)
 
                 v = await circ.read.call_try(sim)
                 await sim.delay(1e-9)
@@ -51,7 +55,7 @@ class TestStack(TestCaseWithSimulator):
 
         async def clear(sim: TestbenchContext):
             while not self.done:
-                await self.random_wait_geom(sim, 0.03)
+                await draw_wait_geom(sim, data, 0.03)
 
                 await circ.clear.call(sim)
                 await sim.delay(3e-9)

--- a/test/lib/test_stack.py
+++ b/test/lib/test_stack.py
@@ -1,7 +1,7 @@
 import pytest
 from transactron.lib.stack import Stack
 from transactron.testing import TestCaseWithSimulator, data_layout, TestbenchContext, SimpleTestCircuit
-from transactron.testing.input_generation import draw_wait_geom
+from transactron.testing.input_generation import draw_wait_geom, shrinkable_constants
 from hypothesis import given, settings
 import hypothesis.strategies as st
 
@@ -16,7 +16,7 @@ class TestStack(TestCaseWithSimulator):
         circ = SimpleTestCircuit(Stack(layout=layout, depth=depth))
         stk: list[int] = []
 
-        cycles = 100
+        cycles = data.draw(shrinkable_constants(100), label="cycles")
 
         self.done = False
 
@@ -24,8 +24,7 @@ class TestStack(TestCaseWithSimulator):
             for _ in range(cycles):
                 await draw_wait_geom(sim, data, 0.5)
 
-                v = data.draw(st.integers(0, 2**width-1))
-                #print(v)
+                v = data.draw(st.integers(0, 2**width - 1), label="val")
                 await circ.write.call(sim, data=v)
                 await sim.delay(2e-9)
                 stk.append(v)

--- a/test/lib/test_storage.py
+++ b/test/lib/test_storage.py
@@ -20,7 +20,7 @@ class TestContentAddressableMemory(TestCaseWithSimulator):
     addr_width = 4
     content_width = 5
     test_number = 30
-    nop_number = 3
+    max_nop = 3
     addr_layout = data_layout(addr_width)
     content_layout = data_layout(content_width)
 
@@ -144,10 +144,10 @@ class TestContentAddressableMemory(TestCaseWithSimulator):
         deadline=timedelta(milliseconds=2000),
     )
     @given(
-        generate_input(test_number, nop_number, amaranth_structs({"addr": addr_layout, "data": content_layout})),
-        generate_input(test_number, nop_number, amaranth_structs({"addr": addr_layout, "data": content_layout})),
-        generate_input(test_number, nop_number, amaranth_structs({"addr": addr_layout})),
-        generate_input(test_number, nop_number, amaranth_structs({"addr": addr_layout})),
+        generate_input(test_number, amaranth_structs({"addr": addr_layout, "data": content_layout}), max_nones=max_nop),
+        generate_input(test_number, amaranth_structs({"addr": addr_layout, "data": content_layout}), max_nones=max_nop),
+        generate_input(test_number, amaranth_structs({"addr": addr_layout}), max_nones=max_nop),
+        generate_input(test_number, amaranth_structs({"addr": addr_layout}), max_nones=max_nop),
     )
     def test_random(self, in_push, in_write, in_read, in_remove):
         self.setUp()

--- a/test/lib/test_storage.py
+++ b/test/lib/test_storage.py
@@ -140,7 +140,6 @@ class TestContentAddressableMemory(TestCaseWithSimulator):
     @settings(
         max_examples=10,
         phases=(Phase.explicit, Phase.reuse, Phase.generate, Phase.shrink),
-        derandomize=True,
         deadline=timedelta(milliseconds=2000),
     )
     @given(

--- a/test/lib/test_storage.py
+++ b/test/lib/test_storage.py
@@ -105,8 +105,10 @@ class TestContentAddressableMemory(TestCaseWithSimulator):
             # The input generator doesn't guarantee that every data gets freed, which leads to lockups.
             # This hack cleans the memory, allowing tests to complete.
             while True:
+                await sim.delay(5e-9)
                 while not self.memory:
                     await sim.tick()
+                    await sim.delay(5e-9)
                 addr = next(iter(self.memory.keys()))
                 del self.memory[addr]
                 await self.circ.remove.call(sim, addr=dict(addr))
@@ -147,7 +149,6 @@ class TestContentAddressableMemory(TestCaseWithSimulator):
         generate_input(test_number, nop_number, amaranth_structs({"addr": addr_layout})),
         generate_input(test_number, nop_number, amaranth_structs({"addr": addr_layout})),
     )
-    @TestCaseWithSimulator.wrap_testing_env_next
     def test_random(self, in_push, in_write, in_read, in_remove):
         self.setUp()
         with self.run_simulation(self.circ, max_cycles=500) as sim:

--- a/test/testing/test_input_generation.py
+++ b/test/testing/test_input_generation.py
@@ -63,7 +63,7 @@ def test_shrinkable_lists(size: int):
     f()
 
     # mostly generates the full size
-    assert sizes.count(size) / len(sizes) >= 0.8
+    assert sizes.count(size) / len(sizes) >= 0.7
 
 
 @pytest.mark.parametrize("size_range", [(0, 5), (0, 20), (5, 20), (3, 3)])
@@ -72,7 +72,9 @@ def test_sized_lists_range(size_range: tuple[int, int]):
     sizes: list[int] = []
     strategy = st.integers(min_value=lo, max_value=hi)
 
-    @settings(max_examples=250)
+    @settings(
+        max_examples=500,
+    )
     @given(sized_lists(strategy, st.integers()))
     def f(elems: list[int]):
         sizes.append(len(elems))
@@ -81,7 +83,10 @@ def test_sized_lists_range(size_range: tuple[int, int]):
 
     f()
 
-    assert lo in sizes and hi in sizes
+    assert lo in sizes
+    expected_avg = (lo + hi) / 2
+    average = sum(sizes) / len(sizes)
+    assert expected_avg * 0.5 <= average <= expected_avg * 1.5
 
 
 def validate_const(shape: ShapeLike, v: Any):

--- a/test/testing/test_input_generation.py
+++ b/test/testing/test_input_generation.py
@@ -6,7 +6,30 @@ from transactron.testing.input_generation import *
 from hypothesis import given, settings, strategies as st
 import pytest
 import itertools
+import math
 import enum as py_enum
+
+
+@pytest.mark.parametrize("prob", [0.2, 0.5, 0.8])
+def test_geometric(prob: float):
+    values: list[int] = []
+
+    expected_avg = (1 - prob) / prob
+
+    # Max value is given because Hypothesis generates outliers more often than distribution implies
+
+    @settings(max_examples=500)
+    @given(geometric(prob, math.ceil(expected_avg * 20)))
+    def f(val):
+        values.append(val)
+        assert isinstance(val, int)
+        assert val >= 0
+
+    f()
+
+    # average is in the right ballpark
+    average = sum(values) / len(values)
+    assert expected_avg / 3 <= average <= expected_avg * 3
 
 
 @pytest.mark.parametrize("value", [10, 1000])
@@ -17,6 +40,7 @@ def test_shrinkable_constants(value: int):
     @given(shrinkable_constants(value))
     def f(val):
         values.append(val)
+        assert isinstance(val, int)
         assert val <= value
 
     f()

--- a/test/testing/test_input_generation.py
+++ b/test/testing/test_input_generation.py
@@ -9,6 +9,22 @@ import itertools
 import enum as py_enum
 
 
+@pytest.mark.parametrize("value", [10, 1000])
+def test_shrinkable_constants(value: int):
+    values: list[int] = []
+
+    @settings(max_examples=200)
+    @given(shrinkable_constants(value))
+    def f(val):
+        values.append(val)
+        assert val <= value
+
+    f()
+
+    # mostly generates the constant value
+    assert values.count(value) / len(values) >= 0.8
+
+
 @pytest.mark.parametrize("size", [5, 20])
 def test_shrinkable_lists(size: int):
     sizes: list[int] = []

--- a/transactron/testing/input_generation.py
+++ b/transactron/testing/input_generation.py
@@ -2,14 +2,20 @@ from collections.abc import Iterable, Mapping
 from typing import Any
 from amaranth import *
 from amaranth import ShapeCastable
+from amaranth.sim._async import SimulatorContext
 from amaranth_types import ShapeLike
 import hypothesis.strategies as st
 import enum as py_enum
+import math
 from amaranth.lib import data
-from hypothesis.strategies import DrawFn, SearchStrategy
+from hypothesis.strategies import DataObject, DrawFn, SearchStrategy
+from .simulator import tick
 
 
 __all__ = [
+    "geometric",
+    "geometric_integer",
+    "draw_wait_geom",
     "shrinkable_lists",
     "sized_lists",
     "amaranth_consts",
@@ -19,6 +25,26 @@ __all__ = [
     "intersperse_range",
     "generate_input",
 ]
+
+
+def geometric(prob: float) -> SearchStrategy[float]:
+    assert prob > 0 and prob <= 1
+    return st.floats(min_value=0, max_value=1, exclude_max=True).map(
+        lambda u: math.log1p(-u) / math.log1p(-prob)
+    )
+
+
+def geometric_integer(prob: float, max_value: int | None = None) -> SearchStrategy[int]:
+    def f(val: float):
+        if max_value is None:
+            return math.floor(val)
+        else:
+            return min(max_value, math.floor(val))
+    return geometric(prob).map(f)
+
+
+async def draw_wait_geom(ctx: SimulatorContext, data: DataObject, prob: float = 0.5, max_cycle_cnt: int = 2**16):
+    await tick(ctx, data.draw(geometric_integer(prob, max_cycle_cnt)))
 
 
 @st.composite

--- a/transactron/testing/input_generation.py
+++ b/transactron/testing/input_generation.py
@@ -13,9 +13,10 @@ from .simulator import tick
 
 
 __all__ = [
+    "exponential",
     "geometric",
-    "geometric_integer",
     "draw_wait_geom",
+    "shrinkable_constants",
     "shrinkable_lists",
     "sized_lists",
     "amaranth_consts",
@@ -27,24 +28,79 @@ __all__ = [
 ]
 
 
-def geometric(prob: float) -> SearchStrategy[float]:
-    assert prob > 0 and prob <= 1
-    return st.floats(min_value=0, max_value=1, exclude_max=True).map(
-        lambda u: math.log1p(-u) / math.log1p(-prob)
-    )
+def exponential(rate: float, max_value: float = math.inf) -> SearchStrategy[float]:
+    """Returns a strategy which generates exponentially distributed floats.
+
+    The distribution is not perfect, but the values shrink to 0.
+
+    Parameters
+    ----------
+    rate : float
+        Rate parameter.
+    max_value : float, optional
+        Maximum generated value. If omitted, no upper bound.
+
+    Returns
+    -------
+    SearchStrategy[float]
+        The constructed strategy.
+    """
+    assert rate > 0
+    return st.floats(min_value=0, max_value=1, exclude_max=True).map(lambda u: min(max_value, -math.log1p(-u) / rate))
 
 
-def geometric_integer(prob: float, max_value: int | None = None) -> SearchStrategy[int]:
+def geometric(prob: float, max_value: int | None = None) -> SearchStrategy[int]:
+    """Returns a strategy which generates geometrically distributed integers.
+
+    The distribution is not perfect, but the values shrink to 0.
+
+    Parameters
+    ----------
+    prob : float
+        Success probability.
+    max_value : int, optional
+        Maximum generated value. If omitted, no upper bound.
+
+    Returns
+    -------
+    SearchStrategy[int]
+        The constructed strategy.
+    """
+
     def f(val: float):
         if max_value is None:
             return math.floor(val)
         else:
             return min(max_value, math.floor(val))
-    return geometric(prob).map(f)
+
+    return exponential(-math.log1p(-prob)).map(f)
 
 
-async def draw_wait_geom(ctx: SimulatorContext, data: DataObject, prob: float = 0.5, max_cycle_cnt: int = 2**16):
-    await tick(ctx, data.draw(geometric_integer(prob, max_cycle_cnt)))
+async def draw_wait_geom(ctx: SimulatorContext, data: DataObject, prob: float = 0.5, max_cycle_cnt: int = 32):
+    """Awaits a random, geometrically distributed number of cycles.
+
+    This is a Hypothesis compatible equivalent of ``random_wait_geom``.
+    """
+    await tick(ctx, data.draw(geometric(prob, max_cycle_cnt), label="wait"))
+
+
+def shrinkable_constants(n: int) -> SearchStrategy[int]:
+    """Returns a strategy which generates an almost constant integer, but shrinkable to 0.
+
+    This allows to write tests which usually do someting a constant amount of times,
+    which can be reduced when searching for a counterexample.
+
+    Parameters
+    ----------
+    n : int
+        The value of the constant.
+
+    Returns
+    -------
+    SearchStrategy[int]
+        The constructed strategy.
+    """
+    return st.integers(min_value=0, max_value=100 * n).map(lambda x: min(x, n))
 
 
 @st.composite
@@ -256,11 +312,14 @@ def intersperse_range[
 
 
 @st.composite
-def generate_input[T](draw: DrawFn, count: int, max_nones: int, strategy: SearchStrategy[T]) -> list[T | None]:
+def generate_input[
+    T
+](draw: DrawFn, count: int, strategy: SearchStrategy[T], prob: float = 0.5, max_nones: int = 32) -> list[T | None]:
     """Useful shorthand for generating inputs for testing processes.
 
-    Optionally, inputs can be interspersed by ``None``, which means no input for
-    a given cycle.
+    Inputs are interspersed by ``None``, which means no input for a given cycle.
+    The delays are geometrically distributed. For some test runs, ``None`` will
+    not be included.
 
     The inputs are generated as shrinkable lists so that short counterexamples
     can be automatically constructed.
@@ -269,14 +328,17 @@ def generate_input[T](draw: DrawFn, count: int, max_nones: int, strategy: Search
     ----------
     count : int
         Number of test inputs to generate.
-    max_nones : int
-        Maximum number of empty inputs in a row. If not given, defaults to 0.
     strategy : SearchStrategy
         Strategy for inputs.
+    max_nones : int
+        Maximum number of empty inputs in a row. If not given, defaults to
+        some preset default.
 
     Returns
     -------
     SearchStrategy
         The constructed strategy.
     """
-    return draw(intersperse_range(shrinkable_lists(count, strategy), st.just(None), max_count=max_nones))
+    do_intersperse = draw(st.booleans())
+    sep_strategy = geometric(prob, max_nones) if do_intersperse else st.just(0)
+    return draw(intersperse_many(shrinkable_lists(count, strategy), st.just(None), sep_strategy))

--- a/transactron/testing/simulator.py
+++ b/transactron/testing/simulator.py
@@ -120,5 +120,5 @@ async def random_wait_geom(ctx: SimulatorContext, prob: float = 0.5, max_cycle_c
     if prob == 1:
         cycle_cnt = 0
     else:
-        cycle_cnt = min(max_cycle_cnt, math.floor(math.log(1 - random.random()) / math.log(1 - prob)))
+        cycle_cnt = min(max_cycle_cnt, math.floor(math.log1p(- random.random()) / math.log1p(- prob)))
     await tick(ctx, cycle_cnt)

--- a/transactron/testing/simulator.py
+++ b/transactron/testing/simulator.py
@@ -120,5 +120,5 @@ async def random_wait_geom(ctx: SimulatorContext, prob: float = 0.5, max_cycle_c
     if prob == 1:
         cycle_cnt = 0
     else:
-        cycle_cnt = min(max_cycle_cnt, math.floor(math.log1p(- random.random()) / math.log1p(- prob)))
+        cycle_cnt = min(max_cycle_cnt, math.floor(math.log1p(-random.random()) / math.log1p(-prob)))
     await tick(ctx, cycle_cnt)

--- a/transactron/testing/test_case_pytest.py
+++ b/transactron/testing/test_case_pytest.py
@@ -6,6 +6,12 @@ __all__ = ["TestCaseWithSimulator"]
 
 
 class TestCaseWithSimulator(TestCaseWithSimulatorBase):
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        for attr in list(vars(cls).values()):
+            if hasattr(attr, "hypothesis"):
+                attr.hypothesis.inner_test = TestCaseWithSimulator.wrap_testing_env_next(attr.hypothesis.inner_test)
+
     @pytest.fixture(autouse=True)
     def fixture_initialize_testing_env(self, request):
         # Hypothesis creates a single instance of a test class, which is later reused multiple times.


### PR DESCRIPTION
It turns out that, indeed, `st.data` works just fine with `pysim`, which opens the way for easy use of Hypothesis even for complex tests.

This PR adds:
- Geometric distribution strategy.
- Hypothesis-driven random delays.
- A trick to avoid manually using `wrap_testing_env_next` (without it, hypothesis tests fail with a weird message).
- A CI hypothesis profile which removes time limits (cycle counts are hardware-independent) and turns on derandomization (constant seed).

Stack test is converted to Hypothesis to showcase that dynamic generation works fine.

TODO:
- [x] Draw labels, for cleaner reports.
- [x] Docstrings.
- [x] Tests.