### PR TITLE
Fix sim performance regression from #221

### DIFF
--- a/transactron/core/body.py
+++ b/transactron/core/body.py
@@ -11,7 +11,7 @@ from transactron.core.transaction_base import TransactionBase
 from amaranth import *
 from amaranth_types import ShapeLike, ValueLike, SrcLoc
 from typing import TYPE_CHECKING, ClassVar, NewType, NotRequired, Optional, Callable, TypedDict, Unpack, final
-from transactron.utils.amaranth_ext.functions import one_hot_mux
+from transactron.utils.amaranth_ext.elaboratables import OneHotMux
 from transactron.utils.assign import AssignArg
 from transactron.utils.transactron_helpers import from_method_layout, method_def_helper
 from transactron.utils.typing import MethodStruct
@@ -119,9 +119,7 @@ class Body(TransactionBase["Body"]):
     @staticmethod
     def _default_combiner(shape: ShapeLike):
         def impl(m: Module, args: Sequence[MethodStruct], runs: Value) -> AssignArg:
-            arg = Signal(shape)
-            m.d.comb += arg.eq(one_hot_mux([(runs[i], args[i]) for i in range(len(args))]))
-            return arg
+            return OneHotMux.create(m, [(runs[i], args[i]) for i in range(len(args))])
 
         return impl
 

--- a/transactron/core/manager.py
+++ b/transactron/core/manager.py
@@ -103,21 +103,21 @@ class MethodMap:
             source: Body,
             ancestors: tuple[MBody, ...],
             call_path: tuple[CtrlPath, ...],
-            call_enable: Value,
+            call_enable: tuple[Value, ...],
         ):
             for method_obj, calls in source.method_calls.items():
                 method = MBody(method_obj._body)
                 for call_ctrl_path, arg_rec, enable_sig in calls:
                     new_ancestors = (method, *ancestors)
                     new_call_path = (*call_path, call_ctrl_path)
-                    new_call_enable = call_enable & enable_sig
+                    new_call_enable = (*call_enable, enable_sig)
 
                     self.info_by_call[(transaction, method)].append(
                         CallInfo(
                             ancestors=new_ancestors,
                             call_path=new_call_path,
                             arg=arg_rec,
-                            enable=new_call_enable,
+                            enable=Cat(new_call_enable).all(),
                         )
                     )
 
@@ -134,7 +134,7 @@ class MethodMap:
 
         for transaction in transactions:
             self.methods_by_transaction[TBody(transaction._body)] = []
-            rec(TBody(transaction._body), transaction._body, (), (), C(1))
+            rec(TBody(transaction._body), transaction._body, (), (), ())
 
         for transaction_or_method in self.methods_and_transactions:
             for method in transaction_or_method.method_calls.keys():
@@ -515,7 +515,7 @@ class TransactionManager(Elaboratable):
                 if method.nonexclusive:
                     return Cat(method._validate_arguments(call.enable, call.arg) for call in calls).all()
 
-                combined = one_hot_mux([(call.enable, call.arg) for call in calls])
+                combined = OneHotMux.create(m, [(call.enable, call.arg) for call in calls])
                 return method._validate_arguments(Cat(call.enable for call in calls).any(), combined)
 
             runnable_terms = [


### PR DESCRIPTION
Turns out #221 massively reduced simulation performance (even in Verilator!). Replacing `OneHotMux.create` by `one_hot_mux` caused that a value expression (not a Signal) became a RHS for `assign`, which led to lots of duplication (basically separate `one_hot_mux` per field, not for an entire record!). Always be aware what is in `Signal` and what is not, we are basically doing metaprogramming here and this is one of the pitfalls.

Also a small change got piggybacked which reduces expression nesting and could improve synthesis results.