### PR TITLE
Add to_signal and top_module

### DIFF
--- a/test/utils/amaranth_ext/test_functions.py
+++ b/test/utils/amaranth_ext/test_functions.py
@@ -1,10 +1,13 @@
+from collections.abc import Callable
 import random
+import pytest
 from amaranth import *
 from amaranth import ShapeCastable
 from amaranth import ValueCastable
 from amaranth.lib import data, enum
-from amaranth_types import ValueLike
-from transactron.utils.amaranth_ext import mux, to_signal
+from amaranth_types import ModuleLike, ValueLike
+from transactron.utils.amaranth_ext import mux, to_signal, top_module
+from transactron.core.tmodule import TModule
 from transactron.testing import TestCaseWithSimulator, TestbenchContext
 
 
@@ -134,6 +137,23 @@ class TestMux(TestCaseWithSimulator):
 
         with self.run_simulation(m) as sim:
             sim.add_testbench(tb)
+
+
+class TestTopModule:
+    def test_top_module_tmodule(self):
+        m = TModule()
+        top_m = top_module(m)
+        assert top_m is m.top_module
+
+    @pytest.mark.parametrize("mod", [Module, TModule])
+    def test_top_module_idempotent(self, mod: Callable[[], ModuleLike]):
+        m = mod()
+
+        top_m_1 = top_module(m)
+        top_m_2 = top_module(m)
+
+        assert top_m_1 is top_m_2
+        assert top_m_1 is not m
 
 
 class TestToSignal(TestCaseWithSimulator):

--- a/test/utils/amaranth_ext/test_functions.py
+++ b/test/utils/amaranth_ext/test_functions.py
@@ -4,7 +4,7 @@ from amaranth import ShapeCastable
 from amaranth import ValueCastable
 from amaranth.lib import data, enum
 from amaranth_types import ValueLike
-from transactron.utils.amaranth_ext import mux
+from transactron.utils.amaranth_ext import mux, to_signal
 from transactron.testing import TestCaseWithSimulator, TestbenchContext
 
 
@@ -131,6 +131,43 @@ class TestMux(TestCaseWithSimulator):
                 ctx.set(in2, {"x": in2_val})
                 out_val = ctx.get(out).x
                 assert out_val == (in1_val if sel_val else in2_val)
+
+        with self.run_simulation(m) as sim:
+            sim.add_testbench(tb)
+
+
+class TestToSignal(TestCaseWithSimulator):
+    def test_value(self):
+        m = Module()
+        sig = Signal(signed(8))
+        out = to_signal(m, ~sig)
+
+        assert isinstance(out, Signal)
+
+        async def tb(ctx: TestbenchContext):
+            for i in range(100):
+                val = random.randrange(-(2 ** (sig.shape().width - 1)), 2 ** (sig.shape().width - 1))
+                ctx.set(sig, val)
+                out_val = ctx.get(out)
+                assert out_val == ~val
+
+        with self.run_simulation(m) as sim:
+            sim.add_testbench(tb)
+
+    def test_struct(self):
+        m = Module()
+        sig = Signal(signed(8))
+        out = to_signal(m, data.StructLayout({"x": signed(8)})(~sig))
+
+        assert isinstance(out, data.View)
+        assert isinstance(out.as_value(), Signal)
+
+        async def tb(ctx: TestbenchContext):
+            for i in range(100):
+                val = random.randrange(-(2 ** (sig.shape().width - 1)), 2 ** (sig.shape().width - 1))
+                ctx.set(sig, val)
+                out_val = ctx.get(out.x)
+                assert out_val == ~val
 
         with self.run_simulation(m) as sim:
             sim.add_testbench(tb)

--- a/transactron/core/tmodule.py
+++ b/transactron/core/tmodule.py
@@ -5,6 +5,7 @@ from amaranth_types import StatementLike, ModuleLike, ValueLike, SwitchKey
 from typing import Optional, Self, NoReturn
 from contextlib import contextmanager
 from amaranth.hdl._dsl import FSM, _guardedcontextmanager
+from transactron.utils.amaranth_ext import top_module
 
 __all__ = ["TModule"]
 
@@ -33,7 +34,7 @@ class _AvoidingModuleBuilderDomains:
         if name == "av_comb":
             return _AvoidingModuleBuilderDomain(self._m.avoiding_module.d["comb"])
         elif name == "top_comb":
-            return _AvoidingModuleBuilderDomain(self._m.top_module.d["comb"])
+            return _AvoidingModuleBuilderDomain(top_module(self._m).d["comb"])
         else:
             return _AvoidingModuleBuilderDomain(self._m.main_module.d[name])
 

--- a/transactron/core/tmodule.py
+++ b/transactron/core/tmodule.py
@@ -215,6 +215,8 @@ class TModule(ModuleLike, Elaboratable):
         self.fsm: Optional[FSM] = None
         self.uid = TModule.__next_uid
         self.path_builder = CtrlPathBuilder(self.uid)
+        self.main_module.submodules._avoiding_module = self.avoiding_module
+        self.main_module.submodules._top_module = self.top_module
         TModule.__next_uid += 1
 
     @_guardedcontextmanager("AvoidedIf")
@@ -305,6 +307,4 @@ class TModule(ModuleLike, Elaboratable):
         self.top_module._MustUse__silence = value  # type: ignore
 
     def elaborate(self, platform):
-        self.main_module.submodules._avoiding_module = self.avoiding_module
-        self.main_module.submodules._top_module = self.top_module
         return self.main_module

--- a/transactron/utils/amaranth_ext/elaboratables.py
+++ b/transactron/utils/amaranth_ext/elaboratables.py
@@ -7,7 +7,7 @@ from amaranth import ValueCastable
 from amaranth.lib.data import ArrayLayout, View
 from amaranth_types import FlatValueLike, HasElaborate, ShapeLike, ModuleLike, ValueLike
 
-from transactron.utils.amaranth_ext.functions import one_hot_mux, shape_of
+from transactron.utils.amaranth_ext.functions import one_hot_mux, shape_of, top_module
 
 __all__ = [
     "OneHotSwitchDynamic",
@@ -281,7 +281,7 @@ class MultiPriorityEncoder(Elaboratable):
 
     @staticmethod
     def create(
-        m: Module, input_width: int, input: ValueLike, outputs_count: int = 1, name: Optional[str] = None
+        m: ModuleLike, input_width: int, input: ValueLike, outputs_count: int = 1, name: Optional[str] = None
     ) -> list[tuple[Value, Value]]:
         """Syntax sugar for creating MultiPriorityEncoder
 
@@ -330,11 +330,14 @@ class MultiPriorityEncoder(Elaboratable):
                 raise ValueError(f"Name: {name} is already in use, so MultiPriorityEncoder can not be added with it.")
             except AttributeError:
                 setattr(m.submodules, name, prio_encoder)
-        m.d.comb += prio_encoder.input.eq(input)
+        top_m = top_module(m)
+        top_m.d.comb += prio_encoder.input.eq(input)
         return [(prio_encoder.outputs[i], prio_encoder.valids[i]) for i in range(outputs_count)]
 
     @staticmethod
-    def create_simple(m: Module, input_width: int, input: ValueLike, name: Optional[str] = None) -> tuple[Value, Value]:
+    def create_simple(
+        m: ModuleLike, input_width: int, input: ValueLike, name: Optional[str] = None
+    ) -> tuple[Value, Value]:
         """Syntax sugar for creating MultiPriorityEncoder
 
         This is the same as `create` function, but with `outputs_count` hardcoded to 1.
@@ -342,7 +345,7 @@ class MultiPriorityEncoder(Elaboratable):
         lst = MultiPriorityEncoder.create(m, input_width, input, outputs_count=1, name=name)
         return lst[0]
 
-    def build_tree(self, m: Module, in_sig: Signal, start_idx: int):
+    def _build_tree(self, m: Module, in_sig: Signal, start_idx: int):
         assert len(in_sig) > 0
         level_outputs = [
             Signal(range(self.input_width), name=f"_lvl_out_idx{start_idx}_{i}") for i in range(self.outputs_count)
@@ -358,8 +361,8 @@ class MultiPriorityEncoder(Elaboratable):
             l_in = Signal(len(in_sig) - middle, name=f"_l_in_idx{start_idx}")
             m.d.comb += r_in.eq(in_sig[0:middle])
             m.d.comb += l_in.eq(in_sig[middle:])
-            r_out, r_val = self.build_tree(m, r_in, start_idx)
-            l_out, l_val = self.build_tree(m, l_in, start_idx + middle)
+            r_out, r_val = self._build_tree(m, r_in, start_idx)
+            l_out, l_val = self._build_tree(m, l_in, start_idx + middle)
 
             with m.Switch(Cat(r_val)):
                 for i in range(self.outputs_count + 1):
@@ -375,7 +378,7 @@ class MultiPriorityEncoder(Elaboratable):
     def elaborate(self, platform):
         m = Module()
 
-        level_outputs, level_valids = self.build_tree(m, self.input, 0)
+        level_outputs, level_valids = self._build_tree(m, self.input, 0)
 
         for k in range(self.outputs_count):
             m.d.comb += self.outputs[k].eq(level_outputs[k])
@@ -429,7 +432,7 @@ class RingMultiPriorityEncoder(Elaboratable):
 
     @staticmethod
     def create(
-        m: Module,
+        m: ModuleLike,
         input_width: int,
         input: ValueLike,
         first: ValueLike,
@@ -492,14 +495,15 @@ class RingMultiPriorityEncoder(Elaboratable):
                 )
             except AttributeError:
                 setattr(m.submodules, name, prio_encoder)
-        m.d.comb += prio_encoder.input.eq(input)
-        m.d.comb += prio_encoder.first.eq(first)
-        m.d.comb += prio_encoder.last.eq(last)
+        top_m = top_module(m)
+        top_m.d.comb += prio_encoder.input.eq(input)
+        top_m.d.comb += prio_encoder.first.eq(first)
+        top_m.d.comb += prio_encoder.last.eq(last)
         return [(prio_encoder.outputs[i], prio_encoder.valids[i]) for i in range(outputs_count)]
 
     @staticmethod
     def create_simple(
-        m: Module, input_width: int, input: ValueLike, first: ValueLike, last: ValueLike, name: Optional[str] = None
+        m: ModuleLike, input_width: int, input: ValueLike, first: ValueLike, last: ValueLike, name: Optional[str] = None
     ) -> tuple[Value, Value]:
         """Syntax sugar for creating RingMultiPriorityEncoder
 
@@ -714,11 +718,12 @@ class OneHotMux(Elaboratable):
 
         fw_net = OneHotMux(input_shape, len(inputs), priority=priority, has_default=default_input is not None)
         m.submodules += fw_net
+        top_m = top_module(m)
         if default_input is not None:
-            m.d.comb += Value.cast(fw_net.default_input).eq(default_input)
+            top_m.d.comb += Value.cast(fw_net.default_input).eq(default_input)
         for i, (sel_bit, input) in enumerate(inputs):
-            m.d.comb += fw_net.select[i].eq(Value.cast(sel_bit).any())
-            m.d.comb += Value.cast(fw_net.inputs[i]).eq(input)
+            top_m.d.comb += fw_net.select[i].eq(Value.cast(sel_bit).any())
+            top_m.d.comb += Value.cast(fw_net.inputs[i]).eq(input)
         return fw_net.output
 
     def elaborate(self, platform):

--- a/transactron/utils/amaranth_ext/functions.py
+++ b/transactron/utils/amaranth_ext/functions.py
@@ -499,5 +499,5 @@ def to_signal(m: ModuleLike, value: ValueLike) -> Signal | ValueCastable:
     """
     sig = Signal.like(value)
     top_m = top_module(m)
-    top_m.comb += Value.cast(sig).eq(Value.cast(value))
+    top_m.d.comb += Value.cast(sig).eq(Value.cast(value))
     return sig

--- a/transactron/utils/amaranth_ext/functions.py
+++ b/transactron/utils/amaranth_ext/functions.py
@@ -452,7 +452,7 @@ def mask_before_first_set_bit(value: Value) -> Value:
     return ~mask_from_first_set_bit(value)
 
 
-def top_module(m: ModuleLike):
+def top_module(m: ModuleLike) -> Module:
     """Returns a top-level module, unaffected by condition contexts.
 
     Intended use: efficient combinational assignments which work with both

--- a/transactron/utils/amaranth_ext/functions.py
+++ b/transactron/utils/amaranth_ext/functions.py
@@ -7,7 +7,7 @@ from amaranth.lib import data, enum
 from collections.abc import Callable, Iterable, Mapping, Sequence
 import operator
 
-from amaranth_types import FlatValueLike, SrcLoc, SwitchKey
+from amaranth_types import FlatValueLike, ModuleLike, SrcLoc, SwitchKey
 from amaranth_types.types import ValueLike, ShapeLike
 from transactron.utils.transactron_helpers import get_src_loc
 from transactron.utils.typing import ValueBundle
@@ -39,6 +39,8 @@ __all__ = [
     "mask_after_first_set_bit",
     "mask_until_first_set_bit",
     "mask_before_first_set_bit",
+    "top_module",
+    "to_signal",
 ]
 
 
@@ -448,3 +450,54 @@ def mask_before_first_set_bit(value: Value) -> Value:
     Same as: ``extract_lowest_set_bit(value) - 1``.
     """
     return ~mask_from_first_set_bit(value)
+
+
+def top_module(m: ModuleLike):
+    """Returns a top-level module, unaffected by condition contexts.
+
+    Intended use: efficient combinational assignments which work with both
+    ``TModule`` and plain ``Module``.
+    """
+    # This hack allows this function to work with both Module and TModule
+    try:
+        return m.submodules._top_module
+    except AttributeError:
+        m.submodules._top_module = Module()
+        return m.submodules._top_module
+
+
+@overload
+def to_signal[T: ValueCastable](m: ModuleLike, value: T) -> T: ...
+
+
+@overload
+def to_signal(m: ModuleLike, value: FlatValueLike) -> Signal: ...
+
+
+def to_signal(m: ModuleLike, value: ValueLike) -> Signal | ValueCastable:
+    """Creates a Signal and immediately assigns it a value.
+
+    Use to avoid expression duplication without a large increase in code size.
+
+    Parameters
+    ----------
+    m : ModuleLike
+        The module where the signal assignment will be performed.
+    value : ValueLike
+        The value to be assigned to a ``Signal``.
+
+    Returns
+    -------
+    ValueLike
+        The created signal. If ``value`` is a ``ValueCastable``, a
+        ``ValueCastable`` of the same type will be returned. Otherwise,
+        a bare ``Signal`` is returned.
+
+    Notes
+    -----
+    Uses ``top_module`` internally.
+    """
+    sig = Signal.like(value)
+    top_m = top_module(m)
+    top_m.comb += Value.cast(sig).eq(Value.cast(value))
+    return sig


### PR DESCRIPTION
To help with issues like the recent one in #230, this PR introduces a low-friction way to assign values into signals.

Also introduces a way to do top level assignment for ModuleLikes.

Fixes #219.