### PR TITLE
Make utils functions 0-wide signal aware

### DIFF
--- a/test/utils/test_utils.py
+++ b/test/utils/test_utils.py
@@ -74,7 +74,7 @@ class PopcountTestCircuit(Elaboratable):
         return m
 
 
-@pytest.mark.parametrize("size", [2, 3, 4, 5, 6, 8, 10, 16, 21, 32, 33, 64, 1025])
+@pytest.mark.parametrize("size", [0, 2, 3, 4, 5, 6, 8, 10, 16, 21, 32, 33, 64, 1025])
 class TestPopcount(TestCaseWithSimulator):
     @pytest.fixture(scope="function", autouse=True)
     def setup_fixture(self, size):

--- a/test/utils/test_utils.py
+++ b/test/utils/test_utils.py
@@ -18,8 +18,7 @@ from transactron.utils import (
     mask_until_first_set_bit,
     mask_before_first_set_bit,
 )
-from transactron.testing.input_generation import shrinkable_lists
-from hypothesis import given, settings
+from hypothesis import given
 import hypothesis.strategies as st
 
 
@@ -171,8 +170,9 @@ def reference_mask_before_first_set_bit(n, width):
 
 class TestBitManipulationFunctions(TestCaseWithSimulator):
     def do_test(self, function, ref_function, data):
+        # TODO: remove simulator when https://codeberg.org/amaranth-lang/rfcs/pulls/88 gets approved and implemented
         async def process(sim: TestbenchContext):
-            width = data.draw(st.integers(min_value=0, max_value=1024))
+            width = data.draw(st.integers(min_value=0, max_value=256))
             value = data.draw(st.integers(min_value=0, max_value=(1 << width) - 1))
             result = sim.get(function(Const(value, width)))
             expected = ref_function(value, width)

--- a/test/utils/test_utils.py
+++ b/test/utils/test_utils.py
@@ -117,7 +117,7 @@ class CLZTestCircuit(Elaboratable):
         return m
 
 
-@pytest.mark.parametrize("size", [1, 2, 3, 4, 5, 6, 7, 8, 9, 15, 16, 17, 31, 32, 33, 63, 64, 65, 97, 98, 127, 128])
+@pytest.mark.parametrize("size", [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 15, 16, 17, 31, 32, 33, 63, 64, 65, 97, 98, 127, 128])
 class TestCountLeadingZeros(TestCaseWithSimulator):
     @pytest.fixture(scope="function", autouse=True)
     def setup_fixture(self, size):
@@ -163,7 +163,7 @@ class CTZTestCircuit(Elaboratable):
         return m
 
 
-@pytest.mark.parametrize("size", [1, 2, 3, 4, 5, 6, 7, 8, 9, 15, 16, 17, 31, 32, 33, 63, 64, 65, 97, 98, 127, 128])
+@pytest.mark.parametrize("size", [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 15, 16, 17, 31, 32, 33, 63, 64, 65, 97, 98, 127, 128])
 class TestCountTrailingZeros(TestCaseWithSimulator):
     @pytest.fixture(scope="function", autouse=True)
     def setup_fixture(self, size):

--- a/test/utils/test_utils.py
+++ b/test/utils/test_utils.py
@@ -18,7 +18,9 @@ from transactron.utils import (
     mask_until_first_set_bit,
     mask_before_first_set_bit,
 )
-from amaranth.utils import ceil_log2
+from transactron.testing.input_generation import shrinkable_lists
+from hypothesis import given, settings
+import hypothesis.strategies as st
 
 
 class TestAlignToPowerOfTwo(unittest.TestCase):
@@ -59,145 +61,6 @@ class TestAlignToPowerOfTwo(unittest.TestCase):
         for num, power, expected in test_cases:
             out = align_down_to_power_of_two(num, power)
             assert expected == out
-
-
-class PopcountTestCircuit(Elaboratable):
-    def __init__(self, size: int):
-        self.sig_in = Signal(size)
-        self.sig_out = Signal(size)
-
-    def elaborate(self, platform):
-        m = Module()
-
-        m.d.comb += self.sig_out.eq(popcount(self.sig_in))
-
-        return m
-
-
-@pytest.mark.parametrize("size", [0, 2, 3, 4, 5, 6, 8, 10, 16, 21, 32, 33, 64, 1025])
-class TestPopcount(TestCaseWithSimulator):
-    @pytest.fixture(scope="function", autouse=True)
-    def setup_fixture(self, size):
-        self.size = size
-        random.seed(14)
-        self.test_number = 40
-        self.m = PopcountTestCircuit(self.size)
-
-    def check(self, sim: TestbenchContext, n):
-        sim.set(self.m.sig_in, n)
-        out_popcount = sim.get(self.m.sig_out)
-        assert out_popcount == n.bit_count(), f"{n:x}"
-
-    async def process(self, sim: TestbenchContext):
-        for i in range(self.test_number):
-            n = random.randrange(2**self.size)
-            self.check(sim, n)
-            sim.delay(1e-6)
-        self.check(sim, 2**self.size - 1)
-
-    def test_popcount(self, size):
-        with self.run_simulation(self.m) as sim:
-            sim.add_testbench(self.process)
-
-
-class CLZTestCircuit(Elaboratable):
-    def __init__(self, xlen: int):
-        self.sig_in = Signal(xlen)
-        self.sig_out = Signal(ceil_log2(xlen) + 1)
-        self.xlen = xlen
-
-    def elaborate(self, platform):
-        m = Module()
-
-        m.d.comb += self.sig_out.eq(count_leading_zeros(self.sig_in))
-        # dummy signal
-        s = Signal()
-        m.d.sync += s.eq(1)
-
-        return m
-
-
-@pytest.mark.parametrize("size", [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 15, 16, 17, 31, 32, 33, 63, 64, 65, 97, 98, 127, 128])
-class TestCountLeadingZeros(TestCaseWithSimulator):
-    @pytest.fixture(scope="function", autouse=True)
-    def setup_fixture(self, size):
-        self.size = size
-        random.seed(14)
-        self.test_number = 40
-        self.m = CLZTestCircuit(self.size)
-
-    def check(self, sim: TestbenchContext, n):
-        sim.set(self.m.sig_in, n)
-        out_clz = sim.get(self.m.sig_out)
-        expected = (self.size) - n.bit_length()
-        assert out_clz == expected, f"Incorrect result: got {out_clz}\t expected: {expected}"
-
-    async def process(self, sim: TestbenchContext):
-        for i in range(self.test_number):
-            n = random.randrange(self.size)
-            self.check(sim, n)
-            sim.delay(1e-6)
-        self.check(sim, 2**self.size - 1)
-        await sim.delay(1e-6)
-        self.check(sim, 0)
-
-    def test_count_leading_zeros(self, size):
-        with self.run_simulation(self.m) as sim:
-            sim.add_testbench(self.process)
-
-
-class CTZTestCircuit(Elaboratable):
-    def __init__(self, xlen: int):
-        self.sig_in = Signal(xlen)
-        self.sig_out = Signal(ceil_log2(xlen) + 1)
-        self.xlen = xlen
-
-    def elaborate(self, platform):
-        m = Module()
-
-        m.d.comb += self.sig_out.eq(count_trailing_zeros(self.sig_in))
-        # dummy signal
-        s = Signal()
-        m.d.sync += s.eq(1)
-
-        return m
-
-
-@pytest.mark.parametrize("size", [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 15, 16, 17, 31, 32, 33, 63, 64, 65, 97, 98, 127, 128])
-class TestCountTrailingZeros(TestCaseWithSimulator):
-    @pytest.fixture(scope="function", autouse=True)
-    def setup_fixture(self, size):
-        self.size = size
-        random.seed(14)
-        self.test_number = 40
-        self.m = CTZTestCircuit(self.size)
-
-    def check(self, sim: TestbenchContext, n):
-        sim.set(self.m.sig_in, n)
-        out_ctz = sim.get(self.m.sig_out)
-
-        expected = 0
-        if n == 0:
-            expected = self.size
-        else:
-            while (n & 1) == 0:
-                expected += 1
-                n >>= 1
-
-        assert out_ctz == expected, f"{n:x}"
-
-    async def process(self, sim: TestbenchContext):
-        for i in range(self.test_number):
-            n = random.randrange(self.size)
-            self.check(sim, n)
-            await sim.delay(1e-6)
-        self.check(sim, self.size - 1)
-        await sim.delay(1e-6)
-        self.check(sim, 0)
-
-    def test_count_trailing_zeros(self, size):
-        with self.run_simulation(self.m) as sim:
-            sim.add_testbench(self.process)
 
 
 class GenCyclicMaskTestCircuit(Elaboratable):
@@ -253,6 +116,20 @@ class TestGenCyclicMask(TestCaseWithSimulator):
             sim.add_testbench(self.process)
 
 
+def reference_popcount(n, width):
+    return n.bit_count()
+
+
+def reference_clz(n, width):
+    return width - n.bit_length()
+
+
+def reference_ctz(n, width):
+    if n == 0:
+        return width
+    return bin(n)[::-1].find("1")
+
+
 def reference_extract_lowest_set_bit(n, width):
     if n == 0:
         return 0
@@ -293,32 +170,49 @@ def reference_mask_before_first_set_bit(n, width):
 
 
 class TestBitManipulationFunctions(TestCaseWithSimulator):
-    def do_test(self, function, ref_function):
+    def do_test(self, function, ref_function, data):
         async def process(sim: TestbenchContext):
-            for _ in range(40):
-                width = random.randint(0, 32)
-                value = random.randint(0, (1 << width) - 1)
-                result = sim.get(function(Const(value, width)))
-                expected = ref_function(value, width)
-                assert result == expected, f"Failed for value {value} with width {width}"
+            width = data.draw(st.integers(min_value=0, max_value=1024))
+            value = data.draw(st.integers(min_value=0, max_value=(1 << width) - 1))
+            result = sim.get(function(Const(value, width)))
+            expected = ref_function(value, width)
+            assert result == expected, f"Failed for value {value} with width {width}"
 
         with self.run_simulation(Module()) as sim:
             sim.add_testbench(process)
 
-    def test_extract_lowest_set_bit(self):
-        self.do_test(extract_lowest_set_bit, reference_extract_lowest_set_bit)
+    @given(st.data())
+    def test_popcount(self, data):
+        self.do_test(popcount, reference_popcount, data)
 
-    def test_clear_lowest_set_bit(self):
-        self.do_test(clear_lowest_set_bit, reference_clear_lowest_set_bit)
+    @given(st.data())
+    def test_count_leading_zeros(self, data):
+        self.do_test(count_leading_zeros, reference_clz, data)
 
-    def test_mask_after_first_set_bit(self):
-        self.do_test(mask_after_first_set_bit, reference_mask_after_first_set_bit)
+    @given(st.data())
+    def test_count_trailing_zeros(self, data):
+        self.do_test(count_trailing_zeros, reference_ctz, data)
 
-    def test_mask_from_first_set_bit(self):
-        self.do_test(mask_from_first_set_bit, reference_mask_from_first_set_bit)
+    @given(st.data())
+    def test_extract_lowest_set_bit(self, data):
+        self.do_test(extract_lowest_set_bit, reference_extract_lowest_set_bit, data)
 
-    def test_mask_until_first_set_bit(self):
-        self.do_test(mask_until_first_set_bit, reference_mask_until_first_set_bit)
+    @given(st.data())
+    def test_clear_lowest_set_bit(self, data):
+        self.do_test(clear_lowest_set_bit, reference_clear_lowest_set_bit, data)
 
-    def test_mask_before_first_set_bit(self):
-        self.do_test(mask_before_first_set_bit, reference_mask_before_first_set_bit)
+    @given(st.data())
+    def test_mask_after_first_set_bit(self, data):
+        self.do_test(mask_after_first_set_bit, reference_mask_after_first_set_bit, data)
+
+    @given(st.data())
+    def test_mask_from_first_set_bit(self, data):
+        self.do_test(mask_from_first_set_bit, reference_mask_from_first_set_bit, data)
+
+    @given(st.data())
+    def test_mask_until_first_set_bit(self, data):
+        self.do_test(mask_until_first_set_bit, reference_mask_until_first_set_bit, data)
+
+    @given(st.data())
+    def test_mask_before_first_set_bit(self, data):
+        self.do_test(mask_before_first_set_bit, reference_mask_before_first_set_bit, data)

--- a/transactron/utils/amaranth_ext/functions.py
+++ b/transactron/utils/amaranth_ext/functions.py
@@ -75,9 +75,6 @@ def popcount(s: Value):
 
 
 def count_trailing_zeros(s: Value) -> Value:
-    if len(s) == 0:
-        return C(0, 0)
-
     def iter(s: Value, step: int) -> Value:
         # if no bits left - return empty value
         if step == 0:

--- a/transactron/utils/amaranth_ext/functions.py
+++ b/transactron/utils/amaranth_ext/functions.py
@@ -75,6 +75,9 @@ def popcount(s: Value):
 
 
 def count_leading_zeros(s: Value) -> Value:
+    if len(s) == 0:
+        return C(0, 0)
+
     def iter(s: Value, step: int) -> Value:
         # if no bits left - return empty value
         if step == 0:

--- a/transactron/utils/amaranth_ext/functions.py
+++ b/transactron/utils/amaranth_ext/functions.py
@@ -74,7 +74,7 @@ def popcount(s: Value):
     )[: bits_for(len(s))]
 
 
-def count_leading_zeros(s: Value) -> Value:
+def count_trailing_zeros(s: Value) -> Value:
     if len(s) == 0:
         return C(0, 0)
 
@@ -91,27 +91,21 @@ def count_leading_zeros(s: Value) -> Value:
         upper_value = iter(s[partition:], step - 1)
         lower_value = iter(s[:partition], step - 1)
 
-        # if there are lit bits in upperhalf - take result directly from recursive value
-        # otherwise add 1 << (step - 1) to lower value and return
-        result = Mux(s[partition:].any(), upper_value, lower_value | current_bit)
-
-        return result
+        # if there are lit bits in lowerhalf - take result directly from recursive value
+        # otherwise add 1 << (step - 1) to upper value and return
+        return Mux(s[:partition].any(), lower_value, upper_value | current_bit)
 
     slen = len(s)
-    slen_log = ceil_log2(slen)
-    closest_pow_2_of_s = 2**slen_log
-    zeros_prepend_count = closest_pow_2_of_s - slen
-    value = iter(Cat(C(0, shape=zeros_prepend_count), s), slen_log)
+    value = iter(s.as_unsigned(), ceil_log2(slen))
 
     # 0 number edge case
     # if s == 0 then iter() returns value off by 1
     # this switch negates this effect
-    result = Mux(s.any(), value, slen)
-    return result
+    return Mux(s.any(), value, slen)
 
 
-def count_trailing_zeros(s: Value) -> Value:
-    return count_leading_zeros(s[::-1])
+def count_leading_zeros(s: Value) -> Value:
+    return count_trailing_zeros(s[::-1])
 
 
 def cyclic_mask(bits: int, start: Value, end: Value):

--- a/transactron/utils/amaranth_ext/functions.py
+++ b/transactron/utils/amaranth_ext/functions.py
@@ -67,21 +67,18 @@ def mod_add(sig: ValueLike, mod: int, incr: ValueLike, max_incr: int):
 
 
 def popcount(s: Value):
-    sum_layers = [s[i] for i in range(len(s))]
-
-    while len(sum_layers) > 1:
-        if len(sum_layers) % 2:
-            sum_layers.append(C(0))
-        sum_layers = [a + b for a, b in zip(sum_layers[::2], sum_layers[1::2])]
-
-    return sum_layers[0][0 : bits_for(len(s))]
+    return binary_tree_reduce(
+        *[s[i] for i in range(len(s))],
+        neutral=C(0, 0),
+        operator=operator.add,
+    )[: bits_for(len(s))]
 
 
 def count_leading_zeros(s: Value) -> Value:
     def iter(s: Value, step: int) -> Value:
         # if no bits left - return empty value
         if step == 0:
-            return C(0)
+            return C(0, 0)
 
         # boudaries of upper and lower halfs of the value
         partition = 2 ** (step - 1)

--- a/transactron/utils/amaranth_ext/functions.py
+++ b/transactron/utils/amaranth_ext/functions.py
@@ -85,7 +85,9 @@ def count_trailing_zeros(s: Value) -> Value:
 
         # boudaries of upper and lower halfs of the value
         partition = 2 ** (step - 1)
-        current_bit = 1 << (step - 1)
+
+        if len(s) < partition:
+            return Cat(iter(s, step - 1), 0)
 
         # recursive call
         upper_value = iter(s[partition:], step - 1)
@@ -93,15 +95,9 @@ def count_trailing_zeros(s: Value) -> Value:
 
         # if there are lit bits in lowerhalf - take result directly from recursive value
         # otherwise add 1 << (step - 1) to upper value and return
-        return Mux(s[:partition].any(), lower_value, upper_value | current_bit)
+        return Mux(s[:partition].any(), Cat(lower_value, 0), Cat(upper_value, 1))
 
-    slen = len(s)
-    value = iter(s.as_unsigned(), ceil_log2(slen))
-
-    # 0 number edge case
-    # if s == 0 then iter() returns value off by 1
-    # this switch negates this effect
-    return Mux(s.any(), value, slen)
+    return iter(s.as_unsigned(), ceil_log2(len(s) + 1))
 
 
 def count_leading_zeros(s: Value) -> Value:


### PR DESCRIPTION
closes #234

- makes `popcount` 0-wide value aware
- makes `count_{leading,trailing}_zeros` 0-wide value aware
- cleans up `count_{leading,trailing}_zeros` to remove the padding logic